### PR TITLE
test(math): add unit tests for `ols_fit` function

### DIFF
--- a/tests/test_ols.py
+++ b/tests/test_ols.py
@@ -1,6 +1,13 @@
 import numpy as np
 import pytest
-from part1.ols_implementation import ols_fit
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+sys.path.append(str(PROJECT_ROOT))
+
+from part1.ols_implementation import ols_fit    
 
 
 class TestOLSFit:

--- a/tests/test_ols.py
+++ b/tests/test_ols.py
@@ -1,0 +1,79 @@
+import numpy as np
+import pytest
+from part1.ols_implementation import ols_fit
+
+
+class TestOLSFit:
+    """Test suite for ols_fit function."""
+
+    def test_recover_parameters_synthetic_data(self):
+        """Test that ols_fit accurately recover parameters from controlled synthetic data.
+
+        Verifies that the estimated β̂  is within error tolerance of the true β
+        when generated from y = Xβ + ε where ε ~ N(0, 0.1).
+        """
+        np.random.seed(42)
+
+        # Define controlled parameters
+        n_samples = 100
+        n_features = 3
+        beta_true = np.array([2.5, 1.0, -0.8])
+        noise_std = 0.1
+
+        # Generate design matrx
+        X = np.random.randn(n_samples, n_features)
+        X[:, 0] = 1  # Intercept col
+
+        # Generate y = Xβ + ε
+        epsilon = np.random.normal(loc=0, scale=noise_std, size=n_samples)
+        y = X @ beta_true + epsilon
+
+        # Fit OLS
+        beta_hat, sigma2_hat = ols_fit(X, y)
+
+        # Assert estimated β is close to true β
+        # Reasonable tolerance with noise std=0.1 and n=100
+        np.testing.assert_array_almost_equal(beta_hat, beta_true, decimal=1)
+
+    def test_larger_sample_size(self):
+        """Test that ols_fit recovers parameters better with larger sample size.
+
+        Verifies robustness across different dataset sizes and noise levels.
+        """
+        np.random.seed(123)
+
+        # Larger dataset for tighter parameter recovery
+        n_samples = 500
+        n_features = 4
+        beta_true = np.array([3.0, -1.5, 2.0, 0.5])
+        noise_std = 0.1
+
+        # Generate data
+        X = np.random.randn(n_samples, n_features)
+        X[:, 0] = 1
+        epsilon = np.random.normal(loc=0, scale=noise_std, size=n_samples)
+        y = X @ beta_true + epsilon
+
+        # Fit OLS
+        beta_hat, sigma2_hat = ols_fit(X, y)
+
+        # Better recovery is expected with increased sample size
+        np.testing.assert_array_almost_equal(beta_hat, beta_true, decimal=2)
+
+    def test_residual_variance_estimate(self):
+        """Test that the residual variance estimator σ̂² is reasonable."""
+        np.random.seed(456)
+
+        n_samples = 200
+        n_features = 2
+        beta_true = np.array([1.0, 2.0])
+        noise_std = 0.1
+
+        X = np.random.randn(n_samples, n_features)
+        X[:, 0] = 1
+        epsilon = np.random.normal(loc=0, scale=noise_std, size=n_samples)
+        y = X @ beta_true + epsilon
+
+        beta_hat, sigma2_hat = ols_fit(X, y)
+
+        assert sigma2_hat == pytest.approx(noise_std**2, rel=0.5)

--- a/tests/test_ols.py
+++ b/tests/test_ols.py
@@ -7,7 +7,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 sys.path.append(str(PROJECT_ROOT))
 
-from part1.ols_implementation import ols_fit    
+from part1.ols_implementation import ols_fit
 
 
 class TestOLSFit:


### PR DESCRIPTION
## 🚀 Description
Add unit tests for `ols_fit` function.

## 🧪 Testing Proof
- [x] I have run `uv run pytest` and all tests passed.
- [x] I have verified the residual plots/metrics.

## 🧹 Quality Check (skip if `pre-commit` hook is installed, simply tick the boxes, do not delete)
- [x] `uv run ruff check .` passed (Style/Linting).
- [x] `uv run interrogate .` meets coverage threshold.
- [x] Docstrings follow the NumPy convention.

