### PR TITLE
fix(part1): intercept column handling in `ols_fit`

### DIFF
--- a/part1/ols_implementation.py
+++ b/part1/ols_implementation.py
@@ -7,12 +7,29 @@ def ols_fit(X, y):
     """
     Compute OLS solution and Residual Variance Estimator.
 
+    An intercept column is prepended internally. Do NOT include one in X.
+
+    Parameters
+    ----------
+    X: array-like of shape (n, p)
+       Design matrix of predictors, without intercept column.
+    y: array-like of shape (n, )
+       Response vector.
+
+    Returns
+    -------
+    beta_hat: ndarray of shape (p + 1, )
+        Estimated coefficients, where beta_hat[0] is the intercept.
+    sigma2: float
+        Residual variance estimate.
+
     Formulas:
     - beta_hat: $\\hat{\\beta} = (X^T X)^{-1} X^T y$
     - sigma2: $\\hat{\\sigma}^2 = \\frac{RSS}{n - p - 1}$
+      where p is the number of predictors (excluding intercept).
     """
-    X = np.array(X)
-    y = np.array(y)
+    X = np.array(X, dtype=float)
+    y = np.array(y, dtype=float)
 
     # 1. Kiểm tra mảng rỗng
     if X.size == 0 or y.size == 0:
@@ -29,6 +46,8 @@ def ols_fit(X, y):
     # Kiểm tra tính tương thích giữa X và y
     if n != y.shape[0]:
         raise ValueError(f"Mismatch: X has {n} samples, y has {y.shape[0]} samples.")
+
+    X = np.column_stack([np.ones(n), X])
 
     # 3. Chặn lỗi chia cho 0 (Guard residual DoF)
     if n - p - 1 <= 0:

--- a/tests/test_ols.py
+++ b/tests/test_ols.py
@@ -1,4 +1,5 @@
 import numpy as np
+from sklearn.linear_model import LinearRegression
 import pytest
 import sys
 from pathlib import Path
@@ -87,3 +88,68 @@ class TestOLSFit:
         rss = np.sum((y - (X_aug @ beta_hat)) ** 2)
         sigma2_expected = rss / (n - p - 1)
         assert sigma2_hat == pytest.approx(sigma2_expected, rel=1e-6)
+
+    def test_metrics_numerical_correctness(self):
+        """Verify TSS, R-squared, Adjusted R-squared, and F-statistic values analytically."""
+
+        # Waiting for model_metrics to be review and merged
+
+        pass
+
+    def test_sklearn_parity(self):
+        """Verify parity with scikit-learn OLS implementation at epsilon = 1e-6."""
+
+        np.random.seed(789)
+
+        n_samples = 80
+        n_features = 5
+        beta_true = np.array([2.0, -1.2, 0.5, 3.1, -0.4, 1.8])
+        noise_std = 0.2
+
+        X = np.random.randn(n_samples, n_features)
+        X_aug = np.column_stack([np.ones(n_samples), X])
+        epsilon = np.random.normal(loc=0, scale=noise_std, size=n_samples)
+        y = X_aug @ beta_true + epsilon
+
+        beta_hat, sigma2_hat = ols_fit(X, y)
+
+        # sklearn fit for ground truth verification
+        reg = LinearRegression(fit_intercept=True)
+        reg.fit(X, y)
+
+        # Merge intercept and coefficients to an array like beta_hat
+        beta_sklearn = np.insert(reg.coef_, 0, reg.intercept_)
+
+        # Restore sigma2 from sklearn
+        y_pred_sklearn = reg.predict(X)
+        rss_sklearn = np.sum((y - y_pred_sklearn) ** 2)
+        sigma2_sklearn = rss_sklearn / (n_samples - n_features - 1)
+
+        np.testing.assert_allclose(beta_hat, beta_sklearn, rtol=1e-6, atol=1e-6)
+        assert sigma2_hat == pytest.approx(sigma2_sklearn, abs=1e-6)
+    
+    def test_dof_edge_case_exact_boundary(self):
+        """Test the exact boundary where n = p + 1. 
+        
+        Residual Degrees of Freedom (n - p - 1) equals 0. 
+        The model perfectly interpolates points; RSS is 0, but variance is undefined (0/0).
+        """
+
+        # 2 samples, 1 predictor => n = 2, p = 1. DoF: 2 - 1 - 1 = 0
+        X = np.array([[1.0], 
+                      [2.0]])
+        y = np.array([3.0, 5.0])
+        
+        with pytest.raises(ValueError, match="Not enough samples to compute variance"):
+            ols_fit(X, y)
+
+    def test_dof_edge_case_insufficient_samples(self):
+        """Test extreme case where n < p + 1 (Overparameterized system)."""
+
+        # 2 samples but with 3 predictors => System has infinite solutions, not enough DoF
+        X = np.array([[1.0, 2.0, 3.0], 
+                      [4.0, 5.0, 6.0]])
+        y = np.array([1.0, 2.0])
+        
+        with pytest.raises(ValueError, match="Not enough samples to compute variance"):
+            ols_fit(X, y)

--- a/tests/test_ols.py
+++ b/tests/test_ols.py
@@ -24,15 +24,19 @@ class TestOLSFit:
 
         # Define controlled parameters
         n_samples = 100
-        n_features = 3 # intercept not included
-        beta_true = np.array([1.5, 2.5, 1.0, -0.8]) # beta thực tế bao gồm cả intercept ở vị trí đầu tiên
+        n_features = 3  # intercept not included
+        beta_true = np.array(
+            [1.5, 2.5, 1.0, -0.8]
+        )  # beta thực tế bao gồm cả intercept ở vị trí đầu tiên
         noise_std = 0.1
 
         # Generate design matrx
         X = np.random.randn(n_samples, n_features)
 
         # Generate y = Xβ + ε
-        X_aug = np.column_stack([np.ones(n_samples), X]) # matches internal logic of ols_fit
+        X_aug = np.column_stack(
+            [np.ones(n_samples), X]
+        )  # matches internal logic of ols_fit
         epsilon = np.random.normal(loc=0, scale=noise_std, size=n_samples)
         y = X_aug @ beta_true + epsilon
 
@@ -91,14 +95,12 @@ class TestOLSFit:
 
     def test_metrics_numerical_correctness(self):
         """Verify TSS, R-squared, Adjusted R-squared, and F-statistic values analytically."""
-
         # Waiting for model_metrics to be review and merged
 
         pass
 
     def test_sklearn_parity(self):
         """Verify parity with scikit-learn OLS implementation at epsilon = 1e-6."""
-
         np.random.seed(789)
 
         n_samples = 80
@@ -127,29 +129,25 @@ class TestOLSFit:
 
         np.testing.assert_allclose(beta_hat, beta_sklearn, rtol=1e-6, atol=1e-6)
         assert sigma2_hat == pytest.approx(sigma2_sklearn, abs=1e-6)
-    
+
     def test_dof_edge_case_exact_boundary(self):
-        """Test the exact boundary where n = p + 1. 
-        
-        Residual Degrees of Freedom (n - p - 1) equals 0. 
+        """Test the exact boundary where n = p + 1.
+
+        Residual Degrees of Freedom (n - p - 1) equals 0.
         The model perfectly interpolates points; RSS is 0, but variance is undefined (0/0).
         """
-
         # 2 samples, 1 predictor => n = 2, p = 1. DoF: 2 - 1 - 1 = 0
-        X = np.array([[1.0], 
-                      [2.0]])
+        X = np.array([[1.0], [2.0]])
         y = np.array([3.0, 5.0])
-        
+
         with pytest.raises(ValueError, match="Not enough samples to compute variance"):
             ols_fit(X, y)
 
     def test_dof_edge_case_insufficient_samples(self):
         """Test extreme case where n < p + 1 (Overparameterized system)."""
-
         # 2 samples but with 3 predictors => System has infinite solutions, not enough DoF
-        X = np.array([[1.0, 2.0, 3.0], 
-                      [4.0, 5.0, 6.0]])
+        X = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         y = np.array([1.0, 2.0])
-        
+
         with pytest.raises(ValueError, match="Not enough samples to compute variance"):
             ols_fit(X, y)

--- a/tests/test_ols.py
+++ b/tests/test_ols.py
@@ -23,17 +23,17 @@ class TestOLSFit:
 
         # Define controlled parameters
         n_samples = 100
-        n_features = 3
-        beta_true = np.array([2.5, 1.0, -0.8])
+        n_features = 3 # intercept not included
+        beta_true = np.array([1.5, 2.5, 1.0, -0.8]) # beta thực tế bao gồm cả intercept ở vị trí đầu tiên
         noise_std = 0.1
 
         # Generate design matrx
         X = np.random.randn(n_samples, n_features)
-        X[:, 0] = 1  # Intercept col
 
         # Generate y = Xβ + ε
+        X_aug = np.column_stack([np.ones(n_samples), X]) # matches internal logic of ols_fit
         epsilon = np.random.normal(loc=0, scale=noise_std, size=n_samples)
-        y = X @ beta_true + epsilon
+        y = X_aug @ beta_true + epsilon
 
         # Fit OLS
         beta_hat, sigma2_hat = ols_fit(X, y)
@@ -52,14 +52,14 @@ class TestOLSFit:
         # Larger dataset for tighter parameter recovery
         n_samples = 500
         n_features = 4
-        beta_true = np.array([3.0, -1.5, 2.0, 0.5])
+        beta_true = np.array([0.5, 3.0, -1.5, 2.0, 0.5])
         noise_std = 0.1
 
         # Generate data
         X = np.random.randn(n_samples, n_features)
-        X[:, 0] = 1
+        X_aug = np.column_stack([np.ones(n_samples), X])
         epsilon = np.random.normal(loc=0, scale=noise_std, size=n_samples)
-        y = X @ beta_true + epsilon
+        y = X_aug @ beta_true + epsilon
 
         # Fit OLS
         beta_hat, sigma2_hat = ols_fit(X, y)
@@ -73,14 +73,17 @@ class TestOLSFit:
 
         n_samples = 200
         n_features = 2
-        beta_true = np.array([1.0, 2.0])
+        beta_true = np.array([2.0, 1.0, 2.0])
         noise_std = 0.1
 
         X = np.random.randn(n_samples, n_features)
-        X[:, 0] = 1
+        X_aug = np.column_stack([np.ones(n_samples), X])
         epsilon = np.random.normal(loc=0, scale=noise_std, size=n_samples)
-        y = X @ beta_true + epsilon
+        y = X_aug @ beta_true + epsilon
 
         beta_hat, sigma2_hat = ols_fit(X, y)
+        n, p = X.shape
 
-        assert sigma2_hat == pytest.approx(noise_std**2, rel=0.5)
+        rss = np.sum((y - (X_aug @ beta_hat)) ** 2)
+        sigma2_expected = rss / (n - p - 1)
+        assert sigma2_hat == pytest.approx(sigma2_expected, rel=1e-6)


### PR DESCRIPTION
## 🚀 Description
Closes #41 
Updated all test suites in `test_ols.py` to correctly handle intercept columns. In addition, a couple more tests were added to strictly check the implementation of `ols_fit`.

## 🧪 Testing Proof
- [x] I have run `uv run pytest` and all tests passed.
- [x] I have verified the residual plots/metrics.

## 🧹 Quality Check (skip if `pre-commit` hook is installed, simply tick the boxes, do not delete)
- [x] `uv run ruff check .` passed (Style/Linting).
- [x] `uv run interrogate .` meets coverage threshold.
- [x] Docstrings follow the NumPy convention.
