### PR TITLE
feat(part1): implement k-fold cv

### DIFF
--- a/part1/cross_validation.py
+++ b/part1/cross_validation.py
@@ -14,8 +14,8 @@ def kfold_cv(X, y, k=5, random_state=None):
         k (int): Number of folds. Default is 5.
         random_state (int, optional): Seed for random shuffling. Default is None.
 
-    Returns:
-        -------
+    Returns
+    -------
         tuple: (Array of MSE for each fold, Mean CV Score)
     """
     X = np.asarray(X)

--- a/part1/cross_validation.py
+++ b/part1/cross_validation.py
@@ -26,8 +26,12 @@ def kfold_cv(X, y, k=5, random_state=None):
         raise ValueError(
             f"Shape mismatch: X has {n_samples} samples, but y has {y.shape[0]} samples."
         )
-    if k < 2 or k > n_samples:
-        raise ValueError(f"Invalid folds: k={k}. Must be between 2 and {n_samples}.")
+    if k < 2:
+        raise ValueError(f"k must be greater than 1. Received k={k}.")
+    if k > n_samples:
+        raise ValueError(
+            f"k cannot exceed number of samples. Received k={k}, n_samples={n_samples}."
+        )
 
     # Tạo mảng chỉ số và thiết lập xáo trộn ngẫu nhiên có fixed seed
     indices = np.arange(n_samples)

--- a/part1/cross_validation.py
+++ b/part1/cross_validation.py
@@ -16,7 +16,8 @@ def kfold_cv(X, y, k=5, random_state=None):
         k (int): Number of folds. Default is 5.
         random_state (int, optional): Seed for random shuffling. Default is None.
 
-    Returns:
+    Returns
+    -------
         tuple: (Array of MSE for each fold, Mean CV Score)
     """
     X = np.asarray(X)

--- a/part1/cross_validation.py
+++ b/part1/cross_validation.py
@@ -1,6 +1,62 @@
 """Module for implementing k-fold cross-validation techniques."""
 
+"""Module for Cross-Validation techniques."""
 
-def kfold_cv(X, y, k):
-    """Perform k-fold cross-validation and compute CV score."""
-    pass
+import numpy as np
+from part1.ols_implementation import ols_fit
+
+
+def kfold_cv(X, y, k=5, random_state=None):
+    """
+    Evaluate model generalization using k-Fold Cross-Validation.
+
+    Args:
+        X (array-like): Design matrix.
+        y (array-like): Target vector.
+        k (int): Number of folds. Default is 5.
+        random_state (int, optional): Seed for random shuffling. Default is None.
+
+    Returns:
+        tuple: (Array of MSE for each fold, Mean CV Score)
+    """
+    X = np.asarray(X)
+    y = np.asarray(y)
+
+    n_samples = X.shape[0]
+
+    # 1. Tạo mảng chỉ số và thiết lập xáo trộn ngẫu nhiên có fixed seed
+    indices = np.arange(n_samples)
+    rng = np.random.RandomState(random_state)
+    rng.shuffle(indices)
+
+    # 2. Chia đều mảng chỉ số thành k phần (folds)
+    folds = np.array_split(indices, k)
+
+    mse_list = []
+
+    # 3. Chạy vòng lặp k lần để train và evaluate
+    for i in range(k):
+        # Lấy fold thứ i làm tập validation (test set)
+        val_idx = folds[i]
+
+        # Lấy k-1 folds còn lại gộp thành tập training
+        train_idx = np.concatenate([folds[j] for j in range(k) if j != i])
+
+        X_train, y_train = X[train_idx], y[train_idx]
+        X_val, y_val = X[val_idx], y[val_idx]
+
+        # Huấn luyện mô hình trên tập train bằng ols_fit (lấy beta_hat, bỏ qua sigma2)
+        beta_hat, _ = ols_fit(X_train, y_train)
+
+        # Dự đoán trên tập validation
+        y_val_pred = X_val @ beta_hat
+
+        # Tính Mean Squared Error (MSE) cho fold hiện tại
+        mse = np.mean((y_val - y_val_pred) ** 2)
+        mse_list.append(mse)
+
+    # 4. Tính toán mảng MSE và điểm trung bình CV Score
+    mse_array = np.array(mse_list)
+    cv_score = np.mean(mse_array)
+
+    return mse_array, cv_score

--- a/part1/cross_validation.py
+++ b/part1/cross_validation.py
@@ -1,5 +1,3 @@
-"""Module for implementing k-fold cross-validation techniques."""
-
 """Module for Cross-Validation techniques."""
 
 import numpy as np
@@ -16,28 +14,33 @@ def kfold_cv(X, y, k=5, random_state=None):
         k (int): Number of folds. Default is 5.
         random_state (int, optional): Seed for random shuffling. Default is None.
 
-    Returns
-    -------
+    Returns:
+        -------
         tuple: (Array of MSE for each fold, Mean CV Score)
     """
     X = np.asarray(X)
     y = np.asarray(y)
 
     n_samples = X.shape[0]
+    if n_samples != y.shape[0]:
+        raise ValueError(
+            f"Shape mismatch: X has {n_samples} samples, but y has {y.shape[0]} samples."
+        )
+    if k < 2 or k > n_samples:
+        raise ValueError(f"Invalid folds: k={k}. Must be between 2 and {n_samples}.")
 
-    # 1. Tạo mảng chỉ số và thiết lập xáo trộn ngẫu nhiên có fixed seed
+    # Tạo mảng chỉ số và thiết lập xáo trộn ngẫu nhiên có fixed seed
     indices = np.arange(n_samples)
     rng = np.random.RandomState(random_state)
     rng.shuffle(indices)
 
-    # 2. Chia đều mảng chỉ số thành k phần (folds)
+    # Chia đều mảng chỉ số thành k phần (folds)
     folds = np.array_split(indices, k)
 
     mse_list = []
 
-    # 3. Chạy vòng lặp k lần để train và evaluate
     for i in range(k):
-        # Lấy fold thứ i làm tập validation (test set)
+        # Lấy fold thứ i làm tập validation
         val_idx = folds[i]
 
         # Lấy k-1 folds còn lại gộp thành tập training
@@ -46,17 +49,22 @@ def kfold_cv(X, y, k=5, random_state=None):
         X_train, y_train = X[train_idx], y[train_idx]
         X_val, y_val = X[val_idx], y[val_idx]
 
-        # Huấn luyện mô hình trên tập train bằng ols_fit (lấy beta_hat, bỏ qua sigma2)
+        # Huấn luyện mô hình
         beta_hat, _ = ols_fit(X_train, y_train)
 
-        # Dự đoán trên tập validation
-        y_val_pred = X_val @ beta_hat
+        # Kiểm tra xem ols_fit có tự động thêm 1 cột Intercept vào beta_hat hay không
+        if beta_hat.shape[0] == X_val.shape[1] + 1:
+            # Nếu có, ta phải gắn thêm 1 cột số 1 vào X_val để kích thước khớp nhau
+            X_val_padded = np.column_stack((np.ones(X_val.shape[0]), X_val))
+            y_val_pred = X_val_padded @ beta_hat
+        else:
+            # Nếu kích thước đã khớp (ols_fit không thêm), thì nhân bình thường
+            y_val_pred = X_val @ beta_hat
 
         # Tính Mean Squared Error (MSE) cho fold hiện tại
         mse = np.mean((y_val - y_val_pred) ** 2)
         mse_list.append(mse)
 
-    # 4. Tính toán mảng MSE và điểm trung bình CV Score
     mse_array = np.array(mse_list)
     cv_score = np.mean(mse_array)
 

--- a/part1/cross_validation.py
+++ b/part1/cross_validation.py
@@ -56,14 +56,9 @@ def kfold_cv(X, y, k=5, random_state=None):
         # Huấn luyện mô hình
         beta_hat, _ = ols_fit(X_train, y_train)
 
-        # Kiểm tra xem ols_fit có tự động thêm 1 cột Intercept vào beta_hat hay không
-        if beta_hat.shape[0] == X_val.shape[1] + 1:
-            # Nếu có, ta phải gắn thêm 1 cột số 1 vào X_val để kích thước khớp nhau
-            X_val_padded = np.column_stack((np.ones(X_val.shape[0]), X_val))
-            y_val_pred = X_val_padded @ beta_hat
-        else:
-            # Nếu kích thước đã khớp (ols_fit không thêm), thì nhân bình thường
-            y_val_pred = X_val @ beta_hat
+        # ols_fit luôn thêm cột intercept và trả về (p+1,) hệ số
+        X_val_aug = np.column_stack([np.ones(len(X_val)), X_val])
+        y_val_pred = X_val_aug @ beta_hat
 
         # Tính Mean Squared Error (MSE) cho fold hiện tại
         mse = np.mean((y_val - y_val_pred) ** 2)

--- a/part1/part1_notebook.ipynb
+++ b/part1/part1_notebook.ipynb
@@ -58,7 +58,7 @@
     "X_demo = np.random.randn(n_samples, p_features)\n",
     "\n",
     "# Định nghĩa beta thực tế bao gồm cả intercept ở vị trí đầu tiên để sinh dữ liệu y\n",
-    "beta_true = np.array([2.5, 1.5, -0.8, 0.5]) \n",
+    "beta_true = np.array([2.5, 1.5, -0.8, 0.5])\n",
     "X_aug_true = np.column_stack([np.ones(n_samples), X_demo])\n",
     "y_demo = X_aug_true @ beta_true + np.random.normal(0, 0.1, n_samples)\n",
     "\n",
@@ -235,18 +235,29 @@
     "X_inference_with_intercept = np.column_stack([np.ones(n_samples), X_inference])\n",
     "\n",
     "# 4. Chạy hàm suy diễn thống kê\n",
-    "inference_results = coef_inference(X_inference_with_intercept, y_inference, beta_hat, sigma2)\n",
+    "inference_results = coef_inference(\n",
+    "    X_inference_with_intercept, y_inference, beta_hat, sigma2\n",
+    ")\n",
     "\n",
     "# 5. In kết quả trực quan ra màn hình Notebook\n",
     "print(\"--- KẾT QUẢ SUY DIỄN THỐNG KÊ (COEF INFERENCE) ---\")\n",
-    "labels = [\"Intercept (Beta0)\", \"Predictor 1 (Beta1)\", \"Predictor 2 (Beta2)\", \"Predictor 3 (Beta3)\"]\n",
+    "labels = [\n",
+    "    \"Intercept (Beta0)\",\n",
+    "    \"Predictor 1 (Beta1)\",\n",
+    "    \"Predictor 2 (Beta2)\",\n",
+    "    \"Predictor 3 (Beta3)\",\n",
+    "]\n",
     "for i, label in enumerate(labels):\n",
     "    print(f\"\\n[{label}]:\")\n",
     "    print(f\"  Hệ số ước lượng (Beta_hat): {beta_hat[i]:.4f}\")\n",
-    "    print(f\"  Sai số chuẩn (SE):          {inference_results['standard_errors'][i]:.4f}\")\n",
+    "    print(\n",
+    "        f\"  Sai số chuẩn (SE):          {inference_results['standard_errors'][i]:.4f}\"\n",
+    "    )\n",
     "    print(f\"  Giá trị t-statistic:        {inference_results['t_statistics'][i]:.4f}\")\n",
     "    print(f\"  Giá trị p-value:            {inference_results['p_values'][i]:.4e}\")\n",
-    "    print(f\"  Khoảng tin cậy 95% (CI):    [{inference_results['ci_lower'][i]:.4f}, {inference_results['ci_upper'][i]:.4f}]\")"
+    "    print(\n",
+    "        f\"  Khoảng tin cậy 95% (CI):    [{inference_results['ci_lower'][i]:.4f}, {inference_results['ci_upper'][i]:.4f}]\"\n",
+    "    )"
    ]
   }
  ],
@@ -266,7 +277,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/tests/test_kfold_cv.py
+++ b/tests/test_kfold_cv.py
@@ -24,11 +24,25 @@ class TestKFoldCV:
 
         # Expect kfold_cv to execute internally or expose metrics per fold
         # For validation, we test if the function executes smoothly and returns a list of scores length k
-        cv_scores, mean_score = kfold_cv(X, y, k=k_folds)
+        cv_scores, mean_score = kfold_cv(X, y, k=k_folds, random_state=0)
 
+        # Check number of folds and data type
         assert len(cv_scores) == k_folds
         assert isinstance(mean_score, float)
         assert mean_score > 0.0
+
+        # Verify mean_score with mean of cv_scores
+        assert mean_score == pytest.approx(np.mean(cv_scores))
+
+        # Verify reproducibility — same seed → same scores
+        cv_scores_2, _ = kfold_cv(X, y, k=k_folds, random_state=0)
+        np.testing.assert_array_equal(cv_scores, cv_scores_2)
+
+        # Verify partition: total samples through all folds = n_samples
+        fold_sizes = [n_samples // k_folds] * k_folds
+        for i in range(n_samples % k_folds):
+            fold_sizes[i] += 1
+        assert sum(fold_sizes) == n_samples
 
     def test_perfect_fit_zero_error(self):
         """Test CV score on a noiseless deterministic system.

--- a/tests/test_kfold_cv.py
+++ b/tests/test_kfold_cv.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pytest
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(PROJECT_ROOT))
+
+from part1.cross_validation import kfold_cv
+
+
+class TestKFoldCV:
+    """Test suite for custom kfold_cv execution framework."""
+
+    def test_cv_fold_splits_integrity(self):
+        """Verify that the indices partition data exactly into k groups without overlaps or omissions."""
+        # Using a simple deterministic setup to monitor partition logic
+        n_samples = 100
+        n_features = 2
+        k_folds = 5
+
+        X = np.random.randn(n_samples, n_features)
+        y = np.random.randn(n_samples)
+
+        # Expect kfold_cv to execute internally or expose metrics per fold
+        # For validation, we test if the function executes smoothly and returns a list of scores length k
+        cv_scores, mean_score = kfold_cv(X, y, k=k_folds)
+
+        assert len(cv_scores) == k_folds
+        assert isinstance(mean_score, float)
+        assert mean_score > 0.0
+
+    def test_perfect_fit_zero_error(self):
+        """Test CV score on a noiseless deterministic system.
+
+        In an ideal linear relationship y = Xβ, every validation fold should yield an MSE close to zero.
+        """
+        np.random.seed(202)
+        n_samples = 60
+        n_features = 2
+        # No noise added
+        X = np.random.randn(n_samples, n_features)
+        X_aug = np.column_stack([np.ones(n_samples), X])
+        beta_true = np.array([1.5, -3.0, 2.5])
+        y = X_aug @ beta_true
+
+        _, mean_score = kfold_cv(X, y, k=3)
+
+        # Mean MSE across folds should be extremely close to 0
+        assert mean_score == pytest.approx(0.0, abs=1e-12)
+
+    def test_invalid_k_raises_error(self):
+        """Test edge cases where k is invalid relative to sample size."""
+        X = np.random.randn(10, 2)
+        y = np.random.randn(10)
+
+        # k must be greater than 1
+        with pytest.raises(ValueError, match="k must be greater than 1"):
+            kfold_cv(X, y, k=1)
+
+        # k cannot exceed n_samples
+        with pytest.raises(ValueError, match="k cannot exceed number of samples"):
+            kfold_cv(X, y, k=15)

--- a/tests/test_kfold_cv.py
+++ b/tests/test_kfold_cv.py
@@ -75,3 +75,56 @@ class TestKFoldCV:
         # k cannot exceed n_samples
         with pytest.raises(ValueError, match="k cannot exceed number of samples"):
             kfold_cv(X, y, k=15)
+
+    def test_reproducibility_with_same_seed(self):
+        """Verify that kfold_cv yields reproducible fold scores given a seed.
+
+        Given the same random_state, kfold_cv must produce identical fold scores
+        across multiple calls. Without this guarantee, any experiment or hyperparameter
+        comparison built on top of this CV function would be unreliable.
+        """
+        np.random.seed(0)
+        X = np.random.randn(60, 3)
+        y = np.random.randn(60)
+
+        scores_1, mean_1 = kfold_cv(X, y, k=5, random_state=42)
+        scores_2, mean_2 = kfold_cv(X, y, k=5, random_state=42)
+
+        np.testing.assert_array_equal(scores_1, scores_2)
+        assert mean_1 == mean_2
+
+    def test_mean_score_equals_mean_of_fold_scores(self):
+        """Verify internal consistency of the returned mean score.
+
+        The returned mean_score must equal exactly np.mean(cv_scores).
+        This verifies internal consistency: if these two values diverge,
+        the aggregation logic is broken regardless of whether individual folds are correct.
+        """
+        np.random.seed(0)
+        X = np.random.randn(50, 2)
+        y = np.random.randn(50)
+
+        scores, mean_score = kfold_cv(X, y, k=5, random_state=7)
+
+        assert mean_score == pytest.approx(np.mean(scores), rel=1e-10)
+
+    def test_higher_noise_yields_higher_cv_score(self):
+        """Validate that CV score scales properly with data noise levels.
+
+        A model trained on high-noise data must produce a higher mean CV score
+        than the same model on low-noise data. This validates that the CV score
+        actually reflects prediction difficulty, not just that the function runs without error.
+        """
+        np.random.seed(0)
+        n, p = 80, 3
+        X = np.random.randn(n, p)
+        X_aug = np.column_stack([np.ones(n), X])
+        beta = np.array([1.0, 2.0, -1.0, 0.5])
+
+        y_low_noise = X_aug @ beta + np.random.normal(0, 0.01, n)
+        y_high_noise = X_aug @ beta + np.random.normal(0, 10.0, n)
+
+        _, score_low = kfold_cv(X, y_low_noise, k=5, random_state=0)
+        _, score_high = kfold_cv(X, y_high_noise, k=5, random_state=0)
+
+        assert score_high > score_low


### PR DESCRIPTION
## 🚀 Description
**Summary of changes:**
- Implemented the `kfold_cv` function in `part1/cross_validation.py` to perform $k$-Fold Cross-Validation
- Handled data shuffling with a `random_state` parameter to ensure reproducibility.
- Integrated the existing `ols_fit` to train and evaluate the model across folds, returning an array of MSEs and the mean CV score.
**Closes:** #46 

## 🧪 Testing Proof
- [x] I have run `uv run pytest` and all tests passed.
- [x] I have verified the residual plots/metrics.

## 🧹 Quality Check (skip if `pre-commit` hook is installed, simply tick the boxes, do not delete)
- [x] `uv run ruff check .` passed (Style/Linting).
- [x] `uv run interrogate .` meets coverage threshold.
- [x] Docstrings follow the NumPy convention.

## 📸 Visuals (Optional)
[Attach screenshots of residual plots or performance traces.]
