### PR TITLE
feat(part1): implement residual_plots

### DIFF
--- a/part1/residual_analysis.py
+++ b/part1/residual_analysis.py
@@ -52,7 +52,10 @@ def residual_plots(X, y, beta_hat):
     mse = np.sum(residuals**2) / (n - p)
 
     # 3. Chuẩn hóa phần dư (Standardized Residuals)
-    std_residuals = residuals / np.sqrt(mse * (1 - h_ii))
+    if np.isclose(mse, 0):
+        std_residuals = np.zeros_like(residuals)
+    else:
+        std_residuals = residuals / np.sqrt(mse * (1 - h_ii))
 
     # 4. Tính khoảng cách Cook (Cook's Distance)
     cooks_d = (std_residuals**2 / p) * (h_ii / (1 - h_ii))

--- a/part1/residual_analysis.py
+++ b/part1/residual_analysis.py
@@ -20,6 +20,9 @@ def residual_plots(X, y, beta_hat):
     Args:
         X (array-like): Design matrix INCLUDING intercept column.
             Must match the X used to compute beta_hat
+            NOTE: Unlike ridge_fit/ols_fit which prepend intercept internally,
+            this function expects X to already contain the intercept column.
+            Example: X_aug = np.column_stack([np.ones(n), X_raw])
         y (array-like): Target vector.
         beta_hat (array-like): Estimated OLS coefficients.
 
@@ -85,11 +88,11 @@ def residual_plots(X, y, beta_hat):
     # --- Plot 3: Scale-Location ---
     sqrt_std_res = np.sqrt(np.abs(std_residuals))
     axes[1, 0].scatter(
-        y_hat, sqrt_std_res, alpha=0.7, edgecolors="k", label="$\sqrt{|Std. Res|}$"
+        y_hat, sqrt_std_res, alpha=0.7, edgecolors="k", label=r"$\sqrt{|Std. Res|}$"
     )
     axes[1, 0].set_title("Scale-Location")
     axes[1, 0].set_xlabel("Fitted values")
-    axes[1, 0].set_ylabel("$\sqrt{|Standardized\ Residuals|}$")
+    axes[1, 0].set_ylabel(r"$\sqrt{|Standardized\ Residuals|}$")
     axes[1, 0].legend()
 
     # --- Plot 4: Cook's Distance ---
@@ -100,7 +103,6 @@ def residual_plots(X, y, beta_hat):
     axes[1, 1].set_ylabel("Cook's Distance")
     axes[1, 1].legend()
 
-    plt.tight_layout()
-    plt.subplots_adjust(top=0.92)  # Nhường chỗ cho title tổng
+    fig.tight_layout(rect=[0, 0, 1, 0.92])
 
     return fig

--- a/part1/residual_analysis.py
+++ b/part1/residual_analysis.py
@@ -1,6 +1,104 @@
-"""Module for creating diagnostic plots to analyze model residuals."""
+"""Module for residual analysis and diagnostic plots."""
+
+import numpy as np
+import matplotlib.pyplot as plt
+import scipy.stats as stats
 
 
 def residual_plots(X, y, beta_hat):
-    """Draw four standard residual plots."""
-    pass
+    """
+    Generate 4 residual diagnostic plots for OLS regression.
+
+    Plots included:
+    1. Residuals vs Fitted
+    2. Normal Q-Q Plot
+    3. Scale-Location
+    4. Cook's Distance
+
+    Args:
+        X (array-like): Design matrix.
+        y (array-like): Target vector.
+        beta_hat (array-like): Estimated OLS coefficients.
+
+    Returns
+    -------
+        matplotlib.figure.Figure: The generated figure containing the 4 subplots.
+    """
+    X = np.asarray(X)
+    y = np.asarray(y)
+    beta_hat = np.asarray(beta_hat)
+
+    n, p = X.shape
+
+    # 1. Tính toán giá trị dự báo và phần dư
+    y_hat = X @ beta_hat
+    residuals = y - y_hat
+
+    # 2. Tính ma trận Hat (Leverage) để chuẩn hóa phần dư và tính Cook's Distance
+    # h_ii là các phần tử trên đường chéo của ma trận Hat
+    xtx_inv = np.linalg.pinv(X.T @ X)
+    H_mat = X @ xtx_inv @ X.T
+    h_ii = np.diag(H_mat)
+
+    # Tránh lỗi chia cho 0 do sai số dấu phẩy động
+    h_ii = np.clip(h_ii, 0, 0.9999)
+
+    # Tính MSE (Mean Squared Error)
+    mse = np.sum(residuals**2) / (n - p)
+
+    # 3. Chuẩn hóa phần dư (Standardized Residuals)
+    std_residuals = residuals / np.sqrt(mse * (1 - h_ii))
+
+    # 4. Tính khoảng cách Cook (Cook's Distance)
+    cooks_d = (std_residuals**2 / p) * (h_ii / (1 - h_ii))
+
+    # ==========================================
+    # VẼ 4 BIỂU ĐỒ (2x2 Layout)
+    # ==========================================
+    fig, axes = plt.subplots(2, 2, figsize=(12, 10))
+    fig.suptitle("Residual Diagnostics Plots", fontsize=16, fontweight="bold")
+
+    # --- Plot 1: Residuals vs Fitted ---
+    axes[0, 0].scatter(y_hat, residuals, alpha=0.7, edgecolors="k", label="Residuals")
+    axes[0, 0].axhline(0, color="red", linestyle="--", label="Zero line")
+    axes[0, 0].set_title("Residuals vs Fitted")
+    axes[0, 0].set_xlabel("Fitted values")
+    axes[0, 0].set_ylabel("Residuals")
+    axes[0, 0].legend()
+
+    # --- Plot 2: Normal Q-Q Plot ---
+    stats.probplot(std_residuals, dist="norm", plot=axes[0, 1])
+    axes[0, 1].get_lines()[0].set_markeredgecolor("k")
+    axes[0, 1].get_lines()[0].set_alpha(0.7)
+    axes[0, 1].get_lines()[1].set_color("red")
+    axes[0, 1].get_lines()[1].set_linestyle("--")
+    axes[0, 1].set_title("Normal Q-Q")
+    axes[0, 1].set_xlabel("Theoretical Quantiles")
+    axes[0, 1].set_ylabel("Standardized Residuals")
+    # Tự tạo legend cho Q-Q plot
+    axes[0, 1].plot([], [], "o", color="blue", label="Data quantiles")
+    axes[0, 1].plot([], [], color="red", linestyle="--", label="Normal line")
+    axes[0, 1].legend()
+
+    # --- Plot 3: Scale-Location ---
+    sqrt_std_res = np.sqrt(np.abs(std_residuals))
+    axes[1, 0].scatter(
+        y_hat, sqrt_std_res, alpha=0.7, edgecolors="k", label="$\sqrt{|Std. Res|}$"
+    )
+    axes[1, 0].set_title("Scale-Location")
+    axes[1, 0].set_xlabel("Fitted values")
+    axes[1, 0].set_ylabel("$\sqrt{|Standardized\ Residuals|}$")
+    axes[1, 0].legend()
+
+    # --- Plot 4: Cook's Distance ---
+    axes[1, 1].stem(range(n), cooks_d, markerfmt=",", basefmt=" ", label="Cook's dist")
+    axes[1, 1].axhline(4 / n, color="red", linestyle="--", label="Threshold (4/n)")
+    axes[1, 1].set_title("Cook's Distance")
+    axes[1, 1].set_xlabel("Observation Index")
+    axes[1, 1].set_ylabel("Cook's Distance")
+    axes[1, 1].legend()
+
+    plt.tight_layout()
+    plt.subplots_adjust(top=0.92)  # Nhường chỗ cho title tổng
+
+    return fig

--- a/part1/residual_analysis.py
+++ b/part1/residual_analysis.py
@@ -4,6 +4,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 import scipy.stats as stats
 
+from part1.ols_implementation import hat_matrix
+
 
 def residual_plots(X, y, beta_hat):
     """
@@ -16,7 +18,8 @@ def residual_plots(X, y, beta_hat):
     4. Cook's Distance
 
     Args:
-        X (array-like): Design matrix.
+        X (array-like): Design matrix INCLUDING intercept column.
+            Must match the X used to compute beta_hat
         y (array-like): Target vector.
         beta_hat (array-like): Estimated OLS coefficients.
 
@@ -36,8 +39,7 @@ def residual_plots(X, y, beta_hat):
 
     # 2. Tính ma trận Hat (Leverage) để chuẩn hóa phần dư và tính Cook's Distance
     # h_ii là các phần tử trên đường chéo của ma trận Hat
-    xtx_inv = np.linalg.pinv(X.T @ X)
-    H_mat = X @ xtx_inv @ X.T
+    H_mat = hat_matrix(X)
     h_ii = np.diag(H_mat)
 
     # Tránh lỗi chia cho 0 do sai số dấu phẩy động

--- a/tests/test_residual_analysis.py
+++ b/tests/test_residual_analysis.py
@@ -146,3 +146,79 @@ class TestResidualAnalysis:
         assert np.all(cooks_d_actual >= 0.0)
 
         plt.close(fig)
+
+    def test_perfect_fit_does_not_crash(self):
+        """Test that a perfect fit model does not crash the function.
+
+        When y equals X @ beta_hat exactly (zero noise), MSE equals zero,
+        which risks division by zero when computing standardized residuals.
+        The function must handle this edge case gracefully without raising any exception.
+        """
+        np.random.seed(0)
+        n = 20
+        X = np.column_stack([np.ones(n), np.random.randn(n, 2)])
+        beta_hat = np.array([1.0, 2.0, -1.0])
+        y = X @ beta_hat  # perfect fit, no noise
+
+        try:
+            fig = residual_plots(X, y, beta_hat)
+            plt.close(fig)
+        except Exception as e:
+            pytest.fail(
+                f"residual_plots raised an unexpected exception on perfect fit: {e}"
+            )
+
+    def test_cooks_distance_threshold_line_at_4_over_n(self):
+        """Verify that Plot 4 draws the Cook's Distance threshold line at 4/n.
+
+        This rule-of-thumb cutoff is the standard visual reference for identifying
+        influential observations and must be rendered at the correct position.
+        """
+        np.random.seed(0)
+        n = 40
+        X = np.column_stack([np.ones(n), np.random.randn(n, 2)])
+        beta_hat = np.array([1.0, 2.0, -1.0])
+        y = X @ beta_hat + np.random.normal(0, 0.2, n)
+
+        fig = residual_plots(X, y, beta_hat)
+        ax = fig.get_axes()[3]
+
+        threshold_lines = [
+            line
+            for line in ax.get_lines()
+            if np.allclose(line.get_ydata(), 4 / n, atol=1e-10)
+        ]
+        try:
+            assert len(threshold_lines) == 1
+        finally:
+            plt.close(fig)
+
+    def test_high_leverage_outlier_has_large_cooks_distance(self):
+        """Test that high-leverage outliers yield a large Cook's Distance.
+
+        An observation that is extreme in both X-space (high leverage) and y-space
+        must produce a Cook's Distance exceeding the 4/n threshold. This verifies that
+        the diagnostic plot can actually detect influential points as intended.
+        """
+        np.random.seed(0)
+        n = 50
+        X_raw = np.random.randn(n, 2)
+        beta_true = np.array([1.0, 2.0, -1.0])
+
+        X_raw[0] = [100.0, 100.0]  # extreme point in X-space
+        X = np.column_stack([np.ones(n), X_raw])
+        y = X @ beta_true
+        y[0] += 500.0  # extreme point in y-space as well
+
+        fig = residual_plots(X, y, beta_true)
+        ax = fig.get_axes()[3]
+
+        stem_container = ax.containers[0]
+        cooks_d = np.array(
+            [seg[1][1] for seg in stem_container.stemlines.get_segments()]
+        )
+
+        try:
+            assert cooks_d[0] > 4 / n
+        finally:
+            plt.close(fig)

--- a/tests/test_residual_analysis.py
+++ b/tests/test_residual_analysis.py
@@ -27,12 +27,12 @@ class TestResidualAnalysis:
         n_samples = 15
         n_features = 3
 
-        X = np.random.randn(n_samples, n_features)
-        beta_true = np.array([1.0, 2.0, -0.5])
-        y = X @ beta_true + np.random.normal(0, 0.1, size=n_samples)
+        X_raw = np.random.randn(n_samples, n_features)
+        X_aug = np.column_stack([np.ones(n_samples), X_raw])
+        beta_true = np.array([1.0, 1.0, 2.0, -0.5])  # intercept + 3 features
+        y = X_aug @ beta_true + np.random.normal(0, 0.1, size=n_samples)
 
-        # Thực thi hàm sinh biểu đồ
-        fig = residual_plots(X, y, beta_true)
+        fig = residual_plots(X_aug, y, beta_true)
 
         # Xác thực kiểu dữ liệu trả về và cấu trúc layout 2x2
         assert isinstance(fig, plt.Figure)

--- a/tests/test_residual_analysis.py
+++ b/tests/test_residual_analysis.py
@@ -12,7 +12,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.append(str(PROJECT_ROOT))
 
 from part1.residual_analysis import residual_plots
-from part1.ols_implementation import ols_fit
+from part1.ols_implementation import ols_fit, hat_matrix
 
 
 class TestResidualAnalysis:
@@ -123,7 +123,7 @@ class TestResidualAnalysis:
         res_expected = y - y_hat_expected
 
         # Tính toán ma trận Hat thủ công: H = X(X^TX)^-1X^T
-        H_mat_expected = X @ np.linalg.pinv(X.T @ X) @ X.T
+        H_mat_expected = hat_matrix(X)
         h_ii_expected = np.diag(H_mat_expected)
         h_ii_expected = np.clip(h_ii_expected, 0, 0.9999)
 

--- a/tests/test_residual_analysis.py
+++ b/tests/test_residual_analysis.py
@@ -96,10 +96,11 @@ class TestResidualAnalysis:
         """
         np.random.seed(456)
         n_samples = 12
-        n_features = 2
+        n_features = 2  # Không tính intercept
 
-        X = np.random.randn(n_samples, n_features)
-        beta_hat = np.array([0.8, 1.5])
+        X_raw = np.random.rand(n_samples, n_features)
+        X = np.column_stack([np.ones(n_samples), X_raw])
+        beta_hat = np.array([0.5, 0.8, 1.5])  # intercept + 2 predictors
         y = X @ beta_hat + np.random.normal(0, 0.2, size=n_samples)
 
         fig = residual_plots(X, y, beta_hat)

--- a/tests/test_residual_analysis.py
+++ b/tests/test_residual_analysis.py
@@ -1,13 +1,18 @@
+import matplotlib
+
+matplotlib.use("Agg")
+
 import numpy as np
 import matplotlib.pyplot as plt
 import pytest
 import sys
 from pathlib import Path
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.append(str(PROJECT_ROOT))
 
 from part1.residual_analysis import residual_plots
+from part1.ols_implementation import ols_fit
 
 
 class TestResidualAnalysis:
@@ -53,16 +58,17 @@ class TestResidualAnalysis:
         """
         np.random.seed(123)
         n_samples = 20
-        n_features = 2  # Cột đầu là intercept, cột sau là biến độc lập
+        n_features = 2
 
-        # Thiết lập ma trận thiết kế có hệ số chặn (cột đầu toàn 1)
-        X = np.column_stack(
-            [np.ones(n_samples), np.random.randn(n_samples, n_features - 1)]
-        )
-        beta_hat = np.array([2.5, -1.2])
-        y = X @ beta_hat + np.random.normal(0, 0.05, size=n_samples)
+        X_raw = np.random.rand(n_samples, n_features - 1)
+        beta_true = np.array([2.5, -1.2])
 
-        fig = residual_plots(X, y, beta_hat)
+        X_full = np.column_stack([np.ones(n_samples), X_raw])
+        y = X_full @ beta_true + np.random.normal(0, 0.05, size=n_samples)
+
+        beta_hat, _ = ols_fit(X_raw, y)
+
+        fig = residual_plots(X_full, y, beta_hat)
         axes = fig.get_axes()
 
         # Trích xuất y_hat và residuals từ Plot 1: Residuals vs Fitted
@@ -71,7 +77,9 @@ class TestResidualAnalysis:
         residuals_extracted = scatter_data[:, 1]
 
         # Kiểm tra công thức cơ bản: y_hat = X @ beta_hat và residuals = y - y_hat
-        np.testing.assert_array_almost_equal(y_hat_extracted, X @ beta_hat, decimal=7)
+        np.testing.assert_array_almost_equal(
+            y_hat_extracted, X_full @ beta_hat, decimal=7
+        )
         np.testing.assert_array_almost_equal(
             residuals_extracted, y - y_hat_extracted, decimal=7
         )

--- a/tests/test_residual_analysis.py
+++ b/tests/test_residual_analysis.py
@@ -1,0 +1,139 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import pytest
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.append(str(PROJECT_ROOT))
+
+from part1.residual_analysis import residual_plots
+
+
+class TestResidualAnalysis:
+    """Test suite for residual_plots function ensuring numerical correctness of underlying metrics."""
+
+    def test_dimensions_and_figure_structure(self):
+        """Verify that the returned object is a valid matplotlib Figure and maintains correct dimensions.
+
+        Checks that the outputs generated internally have a length equal to n.
+        """
+        np.random.seed(42)
+        n_samples = 15
+        n_features = 3
+
+        X = np.random.randn(n_samples, n_features)
+        beta_true = np.array([1.0, 2.0, -0.5])
+        y = X @ beta_true + np.random.normal(0, 0.1, size=n_samples)
+
+        # Thực thi hàm sinh biểu đồ
+        fig = residual_plots(X, y, beta_true)
+
+        # Xác thực kiểu dữ liệu trả về và cấu trúc layout 2x2
+        assert isinstance(fig, plt.Figure)
+        axes = fig.get_axes()
+        assert len(axes) == 4
+
+        # Trích xuất dữ liệu từ Plot 1 (Residuals vs Fitted) để kiểm tra kích thước đầu ra (n)
+        scatter_data = axes[0].collections[0].get_offsets()
+        assert scatter_data.shape[0] == n_samples
+
+        # Trích xuất dữ liệu từ Plot 4 (Cook's Distance) để kiểm tra kích thước đầu ra (n)
+        stem_container = axes[3].containers[0]
+        cooks_d_segments = stem_container.stemlines.get_segments()
+        assert len(cooks_d_segments) == n_samples
+
+        plt.close(fig)
+
+    def test_residuals_properties_and_zero_sum(self):
+        """Verify the algebraic properties of OLS residuals.
+
+        Ensures that the sum of residuals approximates zero when an intercept is present
+        and validates the calculation of y_hat and residuals.
+        """
+        np.random.seed(123)
+        n_samples = 20
+        n_features = 2  # Cột đầu là intercept, cột sau là biến độc lập
+
+        # Thiết lập ma trận thiết kế có hệ số chặn (cột đầu toàn 1)
+        X = np.column_stack(
+            [np.ones(n_samples), np.random.randn(n_samples, n_features - 1)]
+        )
+        beta_hat = np.array([2.5, -1.2])
+        y = X @ beta_hat + np.random.normal(0, 0.05, size=n_samples)
+
+        fig = residual_plots(X, y, beta_hat)
+        axes = fig.get_axes()
+
+        # Trích xuất y_hat và residuals từ Plot 1: Residuals vs Fitted
+        scatter_data = axes[0].collections[0].get_offsets()
+        y_hat_extracted = scatter_data[:, 0]
+        residuals_extracted = scatter_data[:, 1]
+
+        # Kiểm tra công thức cơ bản: y_hat = X @ beta_hat và residuals = y - y_hat
+        np.testing.assert_array_almost_equal(y_hat_extracted, X @ beta_hat, decimal=7)
+        np.testing.assert_array_almost_equal(
+            residuals_extracted, y - y_hat_extracted, decimal=7
+        )
+
+        # Tính chất cốt lõi: Tổng các phần dư phải xấp xỉ bằng 0 (với sai số dấu phẩy động cực nhỏ)
+        assert np.sum(residuals_extracted) == pytest.approx(0.0, abs=1e-10)
+
+        plt.close(fig)
+
+    def test_standardized_residuals_and_cooks_distance(self):
+        """Verify the analytical correctness of Standardized Residuals and Cook's Distance formulas.
+
+        Validates the math logic against an independent exact theoretical implementation.
+        """
+        np.random.seed(456)
+        n_samples = 12
+        n_features = 2
+
+        X = np.random.randn(n_samples, n_features)
+        beta_hat = np.array([0.8, 1.5])
+        y = X @ beta_hat + np.random.normal(0, 0.2, size=n_samples)
+
+        fig = residual_plots(X, y, beta_hat)
+        axes = fig.get_axes()
+
+        # 1. Trích xuất dữ liệu Standardized Residuals thực tế từ trục Y của Plot 2 (Normal Q-Q) hoặc Plot 3
+        scatter_data_p3 = axes[2].collections[0].get_offsets()
+        sqrt_std_res_extracted = scatter_data_p3[:, 1]
+        std_residuals_actual = (
+            sqrt_std_res_extracted**2
+        )  # Vì Plot 3 vẽ căn bậc hai trị tuyệt đối
+
+        # 2. Trích xuất Cook's Distance thực tế từ Plot 4
+        stem_container = axes[3].containers[0]
+        cooks_d_segments = stem_container.stemlines.get_segments()
+        cooks_d_actual = np.array([seg[1][1] for seg in cooks_d_segments])
+
+        # 3. Tính toán lại theo công thức lý thuyết độc lập để đối chứng (Verification)
+        n, p = X.shape
+        y_hat_expected = X @ beta_hat
+        res_expected = y - y_hat_expected
+
+        # Tính toán ma trận Hat thủ công: H = X(X^TX)^-1X^T
+        H_mat_expected = X @ np.linalg.pinv(X.T @ X) @ X.T
+        h_ii_expected = np.diag(H_mat_expected)
+        h_ii_expected = np.clip(h_ii_expected, 0, 0.9999)
+
+        mse_expected = np.sum(res_expected**2) / (n - p)
+        std_res_expected = res_expected / np.sqrt(mse_expected * (1 - h_ii_expected))
+        cooks_d_expected = (std_res_expected**2 / p) * (
+            h_ii_expected / (1 - h_ii_expected)
+        )
+
+        # 4. Assert đối chứng kiểm tra độ khớp chính xác tuyệt đối
+        np.testing.assert_array_almost_equal(
+            std_residuals_actual, np.abs(std_res_expected), decimal=7
+        )
+        np.testing.assert_array_almost_equal(
+            cooks_d_actual, cooks_d_expected, decimal=7
+        )
+
+        # Kiểm tra điều kiện Cook's Distance phải luôn mang giá trị không âm
+        assert np.all(cooks_d_actual >= 0.0)
+
+        plt.close(fig)


### PR DESCRIPTION
## 🚀 Description
**Summary of changes:**
- Implemented the `residual_plots` function in `part1/residual_analysis.py` to generate a 2x2 grid of OLS diagnostic plots (Residuals vs Fitted, Normal Q-Q, Scale-Location, and Cook's Distance).
- Handled underlying matrix calculations for standardized residuals and Cook's distance, including leverage/hat matrix computations with numerical stability safeguards.
**Closes:** #45 

## 🧪 Testing Proof
- [x] I have run `uv run pytest` and all tests passed.
- [x] I have verified the residual plots/metrics.

## 🧹 Quality Check (skip if `pre-commit` hook is installed, simply tick the boxes, do not delete)
- [x] `uv run ruff check .` passed (Style/Linting).
- [x] `uv run interrogate .` meets coverage threshold.
- [x] Docstrings follow the NumPy convention.

## 📸 Visuals (Optional)
[Attach screenshots of residual plots or performance traces.]
