### PR TITLE
feat(part1): implement ridge regression and ridge trace visualization

### DIFF
--- a/part1/ridge_lasso.py
+++ b/part1/ridge_lasso.py
@@ -59,7 +59,8 @@ def plot_ridge_trace(X, y, lambdas=None):
     """
     Plot the Ridge Trace to visualize how coefficients change with lambda.
 
-    Args:
+    Parameters
+    ----------
         X (array-like): Design matrix.
         y (array-like): Target vector.
         lambdas (array-like, optional): Array of lambda values. Defaults to logspace(-3, 3).
@@ -89,8 +90,8 @@ def plot_ridge_trace(X, y, lambdas=None):
         ax.plot(lambdas, betas[:, j], label=f"$\\beta_{{{j}}}$")
 
     ax.set_xscale("log")
-    ax.set_xlabel("$\lambda$ (Log Scale)", fontsize=12)
-    ax.set_ylabel("Coefficients ($\\beta$)", fontsize=12)
+    ax.set_xlabel(r"$\lambda$ (Log Scale)", fontsize=12)
+    ax.set_ylabel(r"Coefficients ($\\beta$)", fontsize=12)
     ax.set_title(
         "Ridge Trace: Coefficient Paths vs. Regularization Strength",
         fontsize=14,

--- a/part1/ridge_lasso.py
+++ b/part1/ridge_lasso.py
@@ -8,29 +8,49 @@ def ridge_fit(X, y, lam):
     """
     Compute Ridge Regression (L2 Regularization) solution using closed-form formula.
 
-    Args:
-        X (array-like): Design matrix.
-        y (array-like): Target vector.
-        lam (float): Regularization parameter (lambda).
+    An intercept column is prepended internally. Do NOT include one in X.
+
+    Parameters
+    ----------
+        X: array-like of shape (n, p)
+           Design matrix of predictors, without intercept column.
+        y: array-like of shape (n, )
+           Response vector.
+        lam: float
+           Regularization parameter (lambda).
 
     Returns
     -------
-        numpy.ndarray: Estimated coefficients beta_hat.
+        beta_hat: ndarray of shape (p + 1, )
+            Estimated coefficients, where beta_hat[0] is the unpenalized intercept.
     """
-    X = np.asarray(X)
-    y = np.asarray(y)
+    X = np.asarray(X, dtype=float)
+    y = np.asarray(y, dtype=float)
+
+    if X.size == 0 or y.size == 0:
+        raise ValueError("Input matrices X and y cannot be empty.")
+    if X.ndim != 2:
+        raise ValueError(f"X must be a 2D array, but got {X.ndim}D.")
+    if y.ndim != 1:
+        raise ValueError(f"y must be a 1D array, but got {y.ndim}D.")
 
     n, p = X.shape
 
+    if n != y.shape[0]:
+        raise ValueError(f"Mismatch: X has {n} samples, y has {y.shape[0]} samples.")
+
+    X_aug = np.column_stack([np.ones(n), X])
+
     # Tạo ma trận đơn vị I
-    I = np.eye(p)
+    I = np.eye(p + 1)
+    I[0, 0] = 0.0
 
     # Công thức đóng: beta_hat = (X^T X + lambda * I)^-1 X^T y
-    xtx = X.T @ X
+    xtx = X_aug.T @ X_aug
     ridge_matrix = xtx + lam * I
 
     # Dùng np.linalg.pinv (giả nghịch đảo) để tính toán an toàn hơn với số học
-    beta_hat = np.linalg.pinv(ridge_matrix) @ X.T @ y
+    beta_hat = np.linalg.pinv(ridge_matrix) @ X_aug.T @ y
 
     return beta_hat
 

--- a/part1/ridge_lasso.py
+++ b/part1/ridge_lasso.py
@@ -50,7 +50,7 @@ def ridge_fit(X, y, lam):
     ridge_matrix = xtx + lam * I
 
     # Dùng np.linalg.pinv (giả nghịch đảo) để tính toán an toàn hơn với số học
-    beta_hat = np.linalg.pinv(ridge_matrix) @ X_aug.T @ y
+    beta_hat = np.linalg.solve(ridge_matrix, X_aug.T @ y)
 
     return beta_hat
 
@@ -91,7 +91,7 @@ def plot_ridge_trace(X, y, lambdas=None):
 
     ax.set_xscale("log")
     ax.set_xlabel(r"$\lambda$ (Log Scale)", fontsize=12)
-    ax.set_ylabel(r"Coefficients ($\\beta$)", fontsize=12)
+    ax.set_ylabel(r"Coefficients ($\beta$)", fontsize=12)
     ax.set_title(
         "Ridge Trace: Coefficient Paths vs. Regularization Strength",
         fontsize=14,

--- a/part1/ridge_lasso.py
+++ b/part1/ridge_lasso.py
@@ -1,6 +1,87 @@
 """Module for Ridge and Lasso regression implementations."""
 
+import numpy as np
+import matplotlib.pyplot as plt
+
 
 def ridge_fit(X, y, lam):
-    """Compute Ridge Regression and draw Ridge Trace."""
-    pass
+    """
+    Compute Ridge Regression (L2 Regularization) solution using closed-form formula.
+
+    Args:
+        X (array-like): Design matrix.
+        y (array-like): Target vector.
+        lam (float): Regularization parameter (lambda).
+
+    Returns
+    -------
+        numpy.ndarray: Estimated coefficients beta_hat.
+    """
+    X = np.asarray(X)
+    y = np.asarray(y)
+
+    n, p = X.shape
+
+    # Tạo ma trận đơn vị I
+    I = np.eye(p)
+
+    # Công thức đóng: beta_hat = (X^T X + lambda * I)^-1 X^T y
+    xtx = X.T @ X
+    ridge_matrix = xtx + lam * I
+
+    # Dùng np.linalg.pinv (giả nghịch đảo) để tính toán an toàn hơn với số học
+    beta_hat = np.linalg.pinv(ridge_matrix) @ X.T @ y
+
+    return beta_hat
+
+
+def plot_ridge_trace(X, y, lambdas=None):
+    """
+    Plot the Ridge Trace to visualize how coefficients change with lambda.
+
+    Args:
+        X (array-like): Design matrix.
+        y (array-like): Target vector.
+        lambdas (array-like, optional): Array of lambda values. Defaults to logspace(-3, 3).
+
+    Returns
+    -------
+        matplotlib.figure.Figure: The generated Ridge Trace plot.
+    """
+    if lambdas is None:
+        # Tạo mảng giá trị lambda từ 10^-3 đến 10^3
+        lambdas = np.logspace(-3, 3, 200)
+
+    X = np.asarray(X)
+    y = np.asarray(y)
+
+    betas = []
+    for lam in lambdas:
+        beta = ridge_fit(X, y, lam)
+        betas.append(beta)
+
+    betas = np.array(betas)
+
+    # Vẽ biểu đồ
+    fig, ax = plt.subplots(figsize=(10, 6))
+
+    for j in range(betas.shape[1]):
+        ax.plot(lambdas, betas[:, j], label=f"$\\beta_{{{j}}}$")
+
+    ax.set_xscale("log")
+    ax.set_xlabel("$\lambda$ (Log Scale)", fontsize=12)
+    ax.set_ylabel("Coefficients ($\\beta$)", fontsize=12)
+    ax.set_title(
+        "Ridge Trace: Coefficient Paths vs. Regularization Strength",
+        fontsize=14,
+        fontweight="bold",
+    )
+    ax.axhline(0, color="black", linestyle="--", linewidth=1)
+
+    # Chỉ hiển thị legend nếu số lượng biến không quá lớn
+    if betas.shape[1] <= 10:
+        ax.legend(loc="best")
+
+    ax.grid(True, alpha=0.3)
+
+    return fig

--- a/part1/ridge_lasso.py
+++ b/part1/ridge_lasso.py
@@ -49,7 +49,7 @@ def ridge_fit(X, y, lam):
     xtx = X_aug.T @ X_aug
     ridge_matrix = xtx + lam * I
 
-    # Dùng np.linalg.pinv (giả nghịch đảo) để tính toán an toàn hơn với số học
+    # Dùng np.linalg.solve (giả nghịch đảo) để tính toán an toàn hơn với số học
     beta_hat = np.linalg.solve(ridge_matrix, X_aug.T @ y)
 
     return beta_hat

--- a/tests/test_ridge_fit.py
+++ b/tests/test_ridge_fit.py
@@ -1,5 +1,10 @@
+import matplotlib
+
+matplotlib.use("Agg")
+
 import numpy as np
 from sklearn.linear_model import Ridge
+import matplotlib.pyplot as plt
 import pytest
 import sys
 from pathlib import Path
@@ -8,7 +13,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.append(str(PROJECT_ROOT))
 
 from part1.ols_implementation import ols_fit
-from part1.ridge_lasso import ridge_fit
+from part1.ridge_lasso import ridge_fit, plot_ridge_trace
 
 
 class TestRidgeFit:
@@ -78,3 +83,66 @@ class TestRidgeFit:
         # Intercept shouldn't be penalized down to zero, but predictors must shrink
         assert np.abs(beta_lam_large[1]) < np.abs(beta_lam_small[1])
         assert np.abs(beta_lam_large[2]) < np.abs(beta_lam_small[2])
+
+
+class TestPlotRidgeTrace:
+    """Test suite for plot_ridge_trace visualization function."""
+
+    @pytest.fixture
+    def sample_data(self):
+        """Fixture to provide consistent toy data for plotting tests."""
+        np.random.seed(42)
+        n_samples = 40
+        n_features = 3
+        X = np.random.randn(n_samples, n_features)
+        y = 2.0 * X[:, 0] - 1.5 * X[:, 1] + np.random.normal(0, 0.1, n_samples)
+        return X, y
+
+    def test_plot_returns_figure_and_does_not_error(self, sample_data):
+        """Verify that the function executes successfully and returns a matplotlib Figure."""
+        X, y = sample_data
+
+        fig = plot_ridge_trace(X, y)
+
+        # Explicitly close the plot to prevent memory leaks during testing
+        try:
+            assert isinstance(fig, plt.Figure)
+        finally:
+            plt.close(fig)
+
+    def test_plot_elements_and_labels(self, sample_data):
+        """Verify that axes labels, title, and scale type are configured correctly."""
+        X, y = sample_data
+
+        fig = plot_ridge_trace(X, y)
+        ax = fig.gca()  # Get current axes
+
+        try:
+            # Check scale type
+            assert ax.get_xscale() == "log"
+
+            # Check that labels and titles are set (stripping spaces/quotes for robust checking)
+            assert "lambda" in ax.get_xlabel().lower()
+            assert "coefficient" in ax.get_ylabel().lower()
+            assert "ridge trace" in ax.get_title().lower()
+        finally:
+            plt.close(fig)
+
+    def test_plot_tracks_all_coefficients(self, sample_data):
+        """Verify that the plot renders paths for all parameters (intercept + features)."""
+        X, y = sample_data
+        n_features = X.shape[1]
+
+        expected_coef_lines = n_features + 1  # 3 features + 1 intercept
+
+        fig = plot_ridge_trace(X, y)
+        ax = fig.gca()
+
+        try:
+            # Check that the number of plotted lines matches our parameter count
+            total_lines = ax.get_lines()
+
+            # The total lines should equal our coefficients plus the 1 axhline baseline
+            assert len(total_lines) == expected_coef_lines + 1
+        finally:
+            plt.close(fig)

--- a/tests/test_ridge_fit.py
+++ b/tests/test_ridge_fit.py
@@ -84,6 +84,56 @@ class TestRidgeFit:
         assert np.abs(beta_lam_large[1]) < np.abs(beta_lam_small[1])
         assert np.abs(beta_lam_large[2]) < np.abs(beta_lam_small[2])
 
+    def test_large_lambda_shrinks_coefficients_to_zero(self):
+        """Test coefficient shrinkage at extreme lambda values.
+
+        When lambda approaches infinity, all penalized coefficients (excluding intercept)
+        must converge to zero.
+        """
+        np.random.seed(0)
+        X = np.random.randn(50, 3)
+        y = np.random.randn(50)
+
+        beta_hat = ridge_fit(X, y, lam=1e10)
+
+        np.testing.assert_allclose(beta_hat[1:], 0.0, atol=1e-4)
+
+    def test_multicollinear_features_returns_stable_solution(self):
+        """Test that Ridge regression handles multicollinearity stably.
+
+        The model must return a finite, stable solution even when X is
+        rank-deficient due to perfectly collinear features.
+        """
+        np.random.seed(0)
+        X_raw = np.random.randn(30, 2)
+        X = np.column_stack(
+            [X_raw, X_raw[:, 0]]
+        )  # column 3 = column 1 (perfect collinearity)
+        y = np.random.randn(30)
+
+        beta_hat = ridge_fit(X, y, lam=1.0)
+
+        assert beta_hat.shape == (4,)  # 3 features + 1 intercept
+        assert np.all(np.isfinite(beta_hat))
+
+    def test_intercept_not_penalized(self):
+        """Test that the intercept is excluded from the L2 penalty.
+
+        When y is shifted by a constant c, beta_hat[0] (intercept) must increase
+        by exactly c while all slope coefficients remain unchanged. This verifies that
+        the intercept is excluded from the L2 penalty as intended by the I[0,0]=0 design.
+        """
+        np.random.seed(0)
+        X = np.random.randn(40, 2)
+        y = np.random.randn(40)
+        c = 100.0
+
+        beta_original = ridge_fit(X, y, lam=5.0)
+        beta_shifted = ridge_fit(X, y + c, lam=5.0)
+
+        np.testing.assert_allclose(beta_shifted[0], beta_original[0] + c, atol=1e-6)
+        np.testing.assert_allclose(beta_shifted[1:], beta_original[1:], atol=1e-6)
+
 
 class TestPlotRidgeTrace:
     """Test suite for plot_ridge_trace visualization function."""

--- a/tests/test_ridge_fit.py
+++ b/tests/test_ridge_fit.py
@@ -1,0 +1,80 @@
+import numpy as np
+from sklearn.linear_model import Ridge
+import pytest
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(PROJECT_ROOT))
+
+from part1.ols_implementation import ols_fit
+from part1.ridge_lasso import ridge_fit
+
+
+class TestRidgeFit:
+    """Test suite for ridge_fit function."""
+
+    def test_lambda_zero_converges_to_ols(self):
+        """Test that ridge_fit with lam=0 yields identical results to ols_fit.
+
+        Verifies the fundamental property that Ridge regression without penalty
+        collides with the Ordinary Least Squares solution.
+        """
+        np.random.seed(42)
+
+        n_samples = 30
+        n_features = 3
+        beta_true = np.array([1.0, -2.0, 0.5, 1.5])
+        noise_std = 0.1
+
+        X = np.random.rand(n_samples, n_features)
+        X_aug = np.column_stack([np.ones(n_samples), X])
+        epsilon = np.random.normal(loc=0, scale=noise_std, size=n_samples)
+        y = X_aug @ beta_true + epsilon
+
+        beta_ols, _ = ols_fit(X, y)
+        beta_ridge = ridge_fit(X, y, lam=0.0)
+
+        np.testing.assert_allclose(beta_ridge, beta_ols, rtol=1e-6, atol=1e-6)
+
+    def test_sklearn_ridge_parity(self):
+        """Verify parity with scikit-learn Ridge implementation at a specific lambda."""
+        np.random.seed(123)
+        n_samples = 100
+        n_features = 4
+        beta_true = np.array([0.5, 2.0, -1.0, 0.8, -1.2])
+        lam = 5.0
+
+        X = np.random.randn(n_samples, n_features)
+        X_aug = np.column_stack([np.ones(n_samples), X])
+        epsilon = np.random.normal(0, 0.2, size=n_samples)
+        y = X_aug @ beta_true + epsilon
+
+        # Custom Ridge implementation
+        beta_hat_custom = ridge_fit(X, y, lam=lam)
+
+        # Scikit-learn Ridge verification
+        # Note: sklearn applies penalty 'alpha' to coefficients but excludes intercept by default
+        reg = Ridge(alpha=lam, fit_intercept=True)
+        reg.fit(X, y)
+        beta_sklearn = np.insert(reg.coef_, 0, reg.intercept_)
+
+        np.testing.assert_allclose(beta_hat_custom, beta_sklearn, rtol=1e-6, atol=1e-6)
+
+    def test_coefficient_shrinkage(self):
+        """Test that increasing lambda strictly shrinks the magnitudes of coefficients (excluding intercept)."""
+        np.random.seed(456)
+        n_samples = 80
+        n_features = 2
+        beta_true = np.array([10.0, 5.0, -5.0])  # Large coefficients
+
+        X = np.random.randn(n_samples, n_features)
+        X_aug = np.column_stack([np.ones(n_samples), X])
+        y = X_aug @ beta_true + np.random.normal(0, 0.1, size=n_samples)
+
+        beta_lam_small = ridge_fit(X, y, lam=0.1)
+        beta_lam_large = ridge_fit(X, y, lam=100.0)
+
+        # Intercept shouldn't be penalized down to zero, but predictors must shrink
+        assert np.abs(beta_lam_large[1]) < np.abs(beta_lam_small[1])
+        assert np.abs(beta_lam_large[2]) < np.abs(beta_lam_small[2])


### PR DESCRIPTION
## 🚀 Description
- Implemented Ridge regression using the closed-form equation in `part1/ridge_lasso.py`.
- Developed `plot_ridge_trace` to visualize parameter shrinkage over a logarithmic range of $\lambda$.
- Added `tests/test_ridge.py` containing unit tests that cross-validate the custom implementation against `sklearn.linear_model.Ridge(fit_intercept=False)` and standard OLS limits.
Closes #44 

## 🧪 Testing Proof
- [x] I have run `uv run pytest` and all tests passed.
- [x] I have verified the residual plots/metrics.

## 🧹 Quality Check (skip if `pre-commit` hook is installed, simply tick the boxes, do not delete)
- [x] `uv run ruff check .` passed (Style/Linting).
- [x] `uv run interrogate .` meets coverage threshold.
- [x] Docstrings follow the NumPy convention.

## 📸 Visuals (Optional)
[Attach screenshots of residual plots or performance traces.]
