### PR TITLE
feat: move scaling from DataPipeline into models (closes #78)

### DIFF
--- a/part2/data_pipeline.py
+++ b/part2/data_pipeline.py
@@ -228,6 +228,11 @@ class DataPipeline:
         """
         Apply preprocessing using stored training parameters.
 
+        Scaling is not applied here — each model handles its own
+        preprocessing internally so that models that don't require
+        scaling (e.g. OLS, Random Forest) receive raw, interpretable
+        feature values.
+
         Parameters
         ----------
         X : pd.DataFrame
@@ -243,8 +248,6 @@ class DataPipeline:
         X = self.handle_missing_values(X)
 
         X = self.encode_categorical(X)
-
-        X = self.scale_features(X)
 
         return X
 

--- a/part2/model_comparison.py
+++ b/part2/model_comparison.py
@@ -91,6 +91,7 @@ class ModelComparison:
             A dict with ``"beta_hat"``, ``"type"``, and scaler parameters
             for use by ``evaluate_model``.
         """
+        feature_names = list(X_train.columns)
         X = np.asarray(X_train, dtype=float)
         y = np.asarray(y_train, dtype=float)
 
@@ -105,6 +106,7 @@ class ModelComparison:
             "type": "ridge",
             "feature_means": feature_means,
             "feature_stds": feature_stds,
+            "feature_names": feature_names,
         }
 
     def train_lasso_regression(
@@ -142,6 +144,7 @@ class ModelComparison:
             "model": model,
             "type": "lasso",
             "scaler": scaler,
+            "feature_names": list(X_train.columns),
         }
 
     def train_elasticnet_regression(
@@ -187,6 +190,7 @@ class ModelComparison:
             "model": model,
             "type": "elasticnet",
             "scaler": scaler,
+            "feature_names": list(X_train.columns),
         }
 
     def evaluate_model(
@@ -218,6 +222,11 @@ class ModelComparison:
             return model.evaluate(X_test, y_test)
 
         if isinstance(model, dict):
+            # Align columns when X_test is a DataFrame (defensive against
+            # column-order mismatch or missing/extra columns vs. training).
+            if "feature_names" in model and hasattr(X_test, "columns"):
+                X_test = X_test.reindex(columns=model["feature_names"])
+
             X = np.asarray(X_test, dtype=float)
 
             if model.get("type") == "ridge":

--- a/part2/model_comparison.py
+++ b/part2/model_comparison.py
@@ -17,6 +17,7 @@ from sklearn.metrics import (
     mean_squared_error,
     r2_score,
 )
+from sklearn.preprocessing import StandardScaler
 
 from part1.ols_implementation import (
     ols_fit,
@@ -69,7 +70,11 @@ class ModelComparison:
         self, X_train: pd.DataFrame, y_train: pd.Series, alpha: float = 1.0
     ) -> Any:
         """
-        Train a Ridge Regression model.
+        Train a Ridge Regression model with internal Z-score scaling.
+
+        Scales features internally so the L2 penalty is applied uniformly
+        regardless of the original feature scales, while keeping the pipeline
+        free to pass raw (unscaled) data.
 
         Parameters
         ----------
@@ -83,23 +88,34 @@ class ModelComparison:
         Returns
         -------
         Any
-            The trained Ridge Regression model instance.
+            A dict with ``"beta_hat"``, ``"type"``, and scaler parameters
+            for use by ``evaluate_model``.
         """
-        X = X_train.values
-        y = y_train.values
+        X = np.asarray(X_train, dtype=float)
+        y = np.asarray(y_train, dtype=float)
 
-        beta_hat = ridge_fit(X, y, lam=alpha)
+        feature_means = np.mean(X, axis=0)
+        feature_stds = np.std(X, axis=0) + 1e-8
+        X_scaled = (X - feature_means) / feature_stds
+
+        beta_hat = ridge_fit(X_scaled, y, lam=alpha)
 
         return {
             "beta_hat": beta_hat,
             "type": "ridge",
+            "feature_means": feature_means,
+            "feature_stds": feature_stds,
         }
 
     def train_lasso_regression(
         self, X_train: pd.DataFrame, y_train: pd.Series, alpha: float = 1.0
     ) -> Any:
         """
-        Train a Lasso Regression model.
+        Train a Lasso Regression model with internal Z-score scaling.
+
+        Scales features internally via ``StandardScaler`` and stores the
+        scaler alongside the fitted model so ``evaluate_model`` can apply
+        the same transformation on test data.
 
         Parameters
         ----------
@@ -113,11 +129,20 @@ class ModelComparison:
         Returns
         -------
         Any
-            The trained Lasso Regression model instance.
+            A dict with ``"model"``, ``"type"``, and ``"scaler"`` for use
+            by ``evaluate_model``.
         """
+        scaler = StandardScaler()
+        X_scaled = scaler.fit_transform(np.asarray(X_train, dtype=float))
+
         model = Lasso(alpha=alpha, random_state=42, max_iter=10000)
-        model.fit(X_train, y_train)
-        return model
+        model.fit(X_scaled, y_train)
+
+        return {
+            "model": model,
+            "type": "lasso",
+            "scaler": scaler,
+        }
 
     def train_elasticnet_regression(
         self,
@@ -127,7 +152,11 @@ class ModelComparison:
         l1_ratio: float = 0.5,
     ) -> Any:
         """
-        Train an ElasticNet Regression model.
+        Train an ElasticNet Regression model with internal Z-score scaling.
+
+        Scales features internally via ``StandardScaler`` and stores the
+        scaler alongside the fitted model so ``evaluate_model`` can apply
+        the same transformation on test data.
 
         Parameters
         ----------
@@ -143,13 +172,22 @@ class ModelComparison:
         Returns
         -------
         Any
-            The trained ElasticNet Regression model instance.
+            A dict with ``"model"``, ``"type"``, and ``"scaler"`` for use
+            by ``evaluate_model``.
         """
+        scaler = StandardScaler()
+        X_scaled = scaler.fit_transform(np.asarray(X_train, dtype=float))
+
         model = ElasticNet(
             alpha=alpha, l1_ratio=l1_ratio, random_state=42, max_iter=10000
         )
-        model.fit(X_train, y_train)
-        return model
+        model.fit(X_scaled, y_train)
+
+        return {
+            "model": model,
+            "type": "elasticnet",
+            "scaler": scaler,
+        }
 
     def evaluate_model(
         self, model: Any, X_test: pd.DataFrame, y_test: pd.Series
@@ -157,10 +195,14 @@ class ModelComparison:
         """
         Evaluate a trained model on testing data.
 
+        Applies the same scaling that was used during training (stored in
+        the model dict) before predicting, so the model receives data in
+        the same space it was trained on.
+
         Parameters
         ----------
         model : Any
-            The trained regression model.
+            The trained regression model (or dict with scaler info).
         X_test : pd.DataFrame
             The testing feature data.
         y_test : pd.Series
@@ -171,14 +213,24 @@ class ModelComparison:
         dict of str to float
             A dictionary containing evaluation metrics (MAE, RMSE, R2).
         """
-        # OLSBaseline uses its own evaluate() method
+        # OLSBaseline uses its own evaluate() method (raw/unscaled data)
         if isinstance(model, OLSBaseline):
             return model.evaluate(X_test, y_test)
 
-        if isinstance(model, dict) and model.get("type") == "ridge":
+        if isinstance(model, dict):
             X = np.asarray(X_test, dtype=float)
-            X_aug = np.column_stack([np.ones(len(X)), X])
-            y_pred = X_aug @ model["beta_hat"]
+
+            if model.get("type") == "ridge":
+                # Ridge from-scratch: scale test data with training params
+                X_scaled = (X - model["feature_means"]) / model["feature_stds"]
+                X_aug = np.column_stack([np.ones(len(X_scaled)), X_scaled])
+                y_pred = X_aug @ model["beta_hat"]
+            elif "scaler" in model:
+                # Lasso / ElasticNet via sklearn: use stored StandardScaler
+                X_scaled = model["scaler"].transform(X)
+                y_pred = model["model"].predict(X_scaled)
+            else:
+                y_pred = model.predict(X_test)
         else:
             y_pred = model.predict(X_test)
 
@@ -197,6 +249,10 @@ class ModelComparison:
     ) -> tuple:
         """
         Select the optimal alpha via k-fold cross-validation.
+
+        Scales each training fold using its own mean/std (to prevent data
+        leakage across folds) so that Ridge regularization is applied
+        uniformly regardless of the original feature scales.
 
         Parameters
         ----------
@@ -229,18 +285,28 @@ class ModelComparison:
         rng.shuffle(indices)
         folds = np.array_split(indices, k)
 
+        # Pre-scale each fold's training set independently (no data leakage)
+        fold_data = []
+        for i in range(k):
+            val_idx = folds[i]
+            train_idx = np.concatenate([folds[j] for j in range(k) if j != i])
+
+            X_tr, X_val = X_arr[train_idx], X_arr[val_idx]
+            y_tr, y_val = y_arr[train_idx], y_arr[val_idx]
+
+            fold_mean = np.mean(X_tr, axis=0)
+            fold_std = np.std(X_tr, axis=0) + 1e-8
+            X_tr_scaled = (X_tr - fold_mean) / fold_std
+            X_val_scaled = (X_val - fold_mean) / fold_std
+
+            fold_data.append((X_tr_scaled, y_tr, X_val_scaled, y_val))
+
         mean_mses = []
 
         for alpha in alphas:
             fold_mses = []
 
-            for i in range(k):
-                val_idx = folds[i]
-                train_idx = np.concatenate([folds[j] for j in range(k) if j != i])
-
-                X_tr, X_val = X_arr[train_idx], X_arr[val_idx]
-                y_tr, y_val = y_arr[train_idx], y_arr[val_idx]
-
+            for X_tr, y_tr, X_val, y_val in fold_data:
                 beta = ridge_fit(X_tr, y_tr, lam=alpha)
                 X_val_aug = np.column_stack([np.ones(len(X_val)), X_val])
                 y_pred = X_val_aug @ beta

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -43,15 +43,20 @@ class TestDataPipeline(unittest.TestCase):
             }
         )
 
-    def test_no_data_leakage_in_scaling(self):
-        """Test 1: Kiểm tra Z-score scaling trên tập test có dùng parameters của tập train hay không."""
+    def test_fit_stores_training_attributes(self):
+        """Test 1: Kiểm tra fit() lưu đúng các tham số thống kê từ tập Train."""
         self.pipeline.fit(self.df_train.drop(columns=["MMSE"]))
-        X_test_transformed = self.pipeline.transform(
-            self.df_test.drop(columns=["MMSE"])
-        )
-        self.assertAlmostEqual(
-            X_test_transformed["nWBV"].iloc[0], 0.5773502691896248, places=6
-        )
+
+        # Must store SES-EDUC group medians
+        self.assertTrue(hasattr(self.pipeline, "ses_educ_medians_"))
+        self.assertIn(12, self.pipeline.ses_educ_medians_)
+
+        # Must store global SES mode
+        self.assertTrue(hasattr(self.pipeline, "ses_global_mode_"))
+
+        # Must store numeric column means/stds
+        self.assertTrue(hasattr(self.pipeline, "numeric_means_"))
+        self.assertIn("nWBV", self.pipeline.numeric_means_)
 
     def test_structural_integrity_categorical(self):
         """Test 2: Kiểm tra tính toàn vẹn cấu trúc cột sau khi xử lý dữ liệu qua Pipeline.

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -45,18 +45,37 @@ class TestDataPipeline(unittest.TestCase):
 
     def test_fit_stores_training_attributes(self):
         """Test 1: Kiểm tra fit() lưu đúng các tham số thống kê từ tập Train."""
-        self.pipeline.fit(self.df_train.drop(columns=["MMSE"]))
+        df = self.df_train.drop(columns=["MMSE"])
+        self.pipeline.fit(df)
 
         # Must store SES-EDUC group medians
         self.assertTrue(hasattr(self.pipeline, "ses_educ_medians_"))
         self.assertIn(12, self.pipeline.ses_educ_medians_)
+        expected_ses_medians = df.groupby("EDUC")["SES"].median().to_dict()
+        self.assertEqual(
+            self.pipeline.ses_educ_medians_[12],
+            expected_ses_medians.get(12),
+        )
 
         # Must store global SES mode
         self.assertTrue(hasattr(self.pipeline, "ses_global_mode_"))
+        expected_ses_mode = df["SES"].mode(dropna=True).iloc[0]
+        self.assertEqual(self.pipeline.ses_global_mode_, expected_ses_mode)
 
         # Must store numeric column means/stds
         self.assertTrue(hasattr(self.pipeline, "numeric_means_"))
         self.assertIn("nWBV", self.pipeline.numeric_means_)
+        self.assertAlmostEqual(
+            self.pipeline.numeric_means_["nWBV"],
+            df["nWBV"].mean(),
+            places=6,
+        )
+        self.assertIn("nWBV", self.pipeline.numeric_stds_)
+        self.assertAlmostEqual(
+            self.pipeline.numeric_stds_["nWBV"],
+            df["nWBV"].std(),
+            places=6,
+        )
 
     def test_structural_integrity_categorical(self):
         """Test 2: Kiểm tra tính toàn vẹn cấu trúc cột sau khi xử lý dữ liệu qua Pipeline.


### PR DESCRIPTION
## Summary

Remove Z-score normalization from DataPipeline.transform() and add internal scaling to the models that need it. Models that don't require scaling (OLS, Random Forest) now receive raw, interpretable features.

## Changes

### part2/data_pipeline.py
- Remove self.scale_features(X) call from transform() — pipeline now only handles missing values + encoding.

### part2/model_comparison.py
- **train_ridge_regression()** — Z-score scales internally before ridge_fit(), stores feature_means/feature_stds in return dict.
- **train_lasso_regression()** — uses StandardScaler, returns dict with fitted model + scaler.
- **train_elasticnet_regression()** — same pattern as Lasso.
- **evaluate_model()** — handles dict returns: scales test data using stored training parameters before predicting.
- **cv_select_alpha()** — scales each fold independently (no data leakage across CV folds).

### tests/test_data_pipeline.py
- Replace test_no_data_leakage_in_scaling with test_fit_stores_training_attributes — verifies fit stores SES-EDUC medians, global mode, and numeric means.

## Impact

| Model | Before | After |
|-------|--------|-------|
| OLSBaseline | Received z-scored features -> coefficients per std-dev | Raw features -> coefficients in clinical units |
| Ridge | Pipeline-scaled | Self-scales internally |
| Lasso/ElasticNet | Pipeline-scaled | Self-scales via StandardScaler |
| KernelRidgeScratch | Double-scaled (pipeline + internal) | Scaled once internally |
| BayesianRegressionScratch | Double-scaled | Scaled once internally |
| RandomForestScratch | Scaled unnecessarily | Raw features (scale-invariant) |

Closes #78
