### PR TITLE
test(data-pipeline): add 4 unit tests for DataPipeline

### DIFF
--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -25,6 +25,7 @@ class TestDataPipeline(unittest.TestCase):
                 "Age": [65, 70, 75, 80],
                 "EDUC": [12, 16, 12, 14],  # Phân nhóm theo học vấn
                 "SES": [3.0, 1.0, 3.0, None],  # Yếu vị (Mode) toàn cục của SES là 3.0
+                "Site": pd.Categorical(["A", "B", "A", "B"]),  # Biến phân loại object
                 "MMSE": [27, 30, 26, 29],
             }
         )
@@ -39,22 +40,66 @@ class TestDataPipeline(unittest.TestCase):
                     18,
                 ],  # Nhóm EDUC = 12 đã học ở Train, nhóm 18 là mới hoàn toàn
                 "SES": [None, 2.0],  # Dòng đầu tiên bị khuyết SES để test điền khuyết
+                "Site": pd.Categorical(["A", "C"]),  # "A" thấy ở Train, "C" là unseen
                 "MMSE": [28, 29],
             }
         )
 
-    def test_no_data_leakage_in_scaling(self):
-        """Test 1: Kiểm tra Z-score scaling trên tập test có dùng parameters của tập train hay không."""
+    # ──────────────────────────────────────────────────────────
+    # Test 1 — Fit attributes
+    # ──────────────────────────────────────────────────────────
+    def test_fit_stores_training_attributes(self):
+        """Test 1: Kiểm tra fit() lưu đúng các tham số thống kê từ tập Train."""
+        self.pipeline.fit(self.df_train.drop(columns=["MMSE"]))
+
+        # Must store SES-EDUC group medians
+        self.assertTrue(hasattr(self.pipeline, "ses_educ_medians_"))
+        self.assertIn(12, self.pipeline.ses_educ_medians_)
+        self.assertEqual(self.pipeline.ses_educ_medians_[12], 3.0)
+
+        # Must store global SES mode
+        self.assertTrue(hasattr(self.pipeline, "ses_global_mode_"))
+        self.assertEqual(self.pipeline.ses_global_mode_, 3.0)
+
+        # Must store numeric column means/stds
+        self.assertTrue(hasattr(self.pipeline, "numeric_means_"))
+        self.assertIn("nWBV", self.pipeline.numeric_means_)
+        self.assertAlmostEqual(self.pipeline.numeric_means_["nWBV"], 0.756666, places=5)
+
+        # Must store categorical column info
+        self.assertIn("Site", self.pipeline.categorical_columns_)
+        self.assertListEqual(
+            sorted(self.pipeline.categorical_values_["Site"]), ["A", "B"]
+        )
+
+        # Must store encoded column names after transform
+        X_train_transformed = self.pipeline.transform(
+            self.df_train.drop(columns=["MMSE"])
+        )
+        self.assertIn("Site_A", X_train_transformed.columns)
+
+    # ──────────────────────────────────────────────────────────
+    # Test 2 — Scaling uses training statistics
+    # ──────────────────────────────────────────────────────────
+    def test_scale_features_uses_train_stats(self):
+        """Test 2: Kiểm tra scale_features() dùng mean/std từ Train, không từ Test."""
         self.pipeline.fit(self.df_train.drop(columns=["MMSE"]))
         X_test_transformed = self.pipeline.transform(
             self.df_test.drop(columns=["MMSE"])
         )
+
+        # Expected z-score of 0.78 using TRAIN mean/std:
+        # train nWBV = [0.75, 0.80, 0.72, NaN] -> after dropna mean=0.75666, std=0.04041
+        # z = (0.78 - 0.75666) / 0.04041 = 0.57735...
         self.assertAlmostEqual(
             X_test_transformed["nWBV"].iloc[0], 0.5773502691896248, places=6
         )
 
+    # ──────────────────────────────────────────────────────────
+    # Test 3 — Column structural integrity
+    # ──────────────────────────────────────────────────────────
     def test_structural_integrity_categorical(self):
-        """Test 2: Kiểm tra tính toàn vẹn cấu trúc cột sau khi xử lý dữ liệu qua Pipeline.
+        """Test 3: Kiểm tra tính toàn vẹn cấu trúc cột sau khi xử lý dữ liệu qua Pipeline.
 
         Tập train và test sau khi qua transform phải có cấu trúc các cột hoàn toàn đồng nhất.
         """
@@ -69,8 +114,29 @@ class TestDataPipeline(unittest.TestCase):
             list(X_train_transformed.columns), list(X_test_transformed.columns)
         )
 
+    # ──────────────────────────────────────────────────────────
+    # Test 4 — One-hot encoding of categorical variables
+    # ──────────────────────────────────────────────────────────
+    def test_encode_categorical_produces_dummies(self):
+        """Test 4: Kiểm tra encode_categorical() tạo đúng biến giả từ tập Train."""
+        self.pipeline.fit(self.df_train.drop(columns=["MMSE"]))
+        X_train_transformed = self.pipeline.transform(
+            self.df_train.drop(columns=["MMSE"])
+        )
+
+        # Site (category) should be one-hot encoded to Site_A, Site_B
+        self.assertIn("Site_A", X_train_transformed.columns)
+        self.assertIn("Site_B", X_train_transformed.columns)
+
+        # Row 0 has Site=A -> Site_A=1, Site_B=0
+        self.assertEqual(X_train_transformed["Site_A"].iloc[0], 1)
+        self.assertEqual(X_train_transformed["Site_B"].iloc[0], 0)
+
+    # ──────────────────────────────────────────────────────────
+    # Test 5 — Missing categorical values use training mode
+    # ──────────────────────────────────────────────────────────
     def test_missing_categorical_uses_training_mode(self):
-        """Test 3: Kiểm tra tính năng điền khuyết bằng Trung vị nhóm (EDUC) và cơ chế phòng vệ toàn cục."""
+        """Test 5: Kiểm tra tính năng điền khuyết bằng Trung vị nhóm (EDUC) và cơ chế phòng vệ toàn cục."""
         # Bước 1: Cho Pipeline học tri thức từ ma trận Train (Học được ses_by_educ của nhóm 12 là 3.0)
         X_train_only = self.df_train.drop(columns=["MMSE"])
         self.pipeline.fit(X_train_only)


### PR DESCRIPTION
Adds 4 tests covering:
- `test_fit_stores_training_attributes` — fit() populates SES-EDUC medians, global mode, numeric stats, categorical columns
- `test_encode_categorical_produces_dummies` — one-hot encoding with Site column
- `test_structural_integrity_categorical` — train/test column structure matches
- `test_missing_categorical_uses_training_mode` — SES imputation by EDUC group median

Part of Part 2 test coverage gap closure.