### PR TITLE
Archive out-of-scope models (Lasso, ElasticNet, Bayesian, RF) to part2/archive/

### DIFF
--- a/part2/advanced_methods.py
+++ b/part2/advanced_methods.py
@@ -1,12 +1,11 @@
 """
-Advanced Methods From Scratch Module.
+Advanced Methods Module.
 
 This module provides the AdvancedMethods class to implement
-and evaluate advanced regression techniques completely from scratch
-using pure NumPy matrix operations.
+and evaluate advanced regression techniques.
 """
 
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -112,313 +111,6 @@ class KernelRidgeScratch:
         return np.dot(K_test, self.dual_coefficients_)
 
 
-class BayesianLinearRegressionScratch:
-    """Bayesian Linear Regression using Gaussian Priors with Z-score scaling."""
-
-    def __init__(self, alpha: float = 1.0, beta: float = 25.0) -> None:
-        """Initialize the Bayesian Regression model with precision parameters.
-
-        Parameters
-        ----------
-        alpha : float, optional
-            Prior precision (inverse variance) on the weight vector.
-            Controls the strength of the zero-mean Gaussian prior.
-            Default is 1.0.
-        beta : float, optional
-            Noise precision (inverse variance) of the likelihood.
-            Equivalent to 1 / sigma^2 of the observation noise.
-            Default is 25.0.
-        """
-        self.alpha = alpha
-        self.beta = beta
-        self.w_mean: Optional[np.ndarray] = None
-        self.w_cov: Optional[np.ndarray] = None
-        self.feature_means: Optional[np.ndarray] = None
-        self.feature_stds: Optional[np.ndarray] = None
-
-    def fit(self, X: Any, y: Any) -> "BayesianLinearRegressionScratch":
-        """Fit the Bayesian linear regression and calculate posterior.
-
-        Z-score scales features first so the zero-mean Gaussian prior
-        is applied uniformly across features regardless of their original
-        scale. Augments features with a bias column, then computes the
-        posterior precision matrix S^{-1} = alpha * I + beta * X^T X
-        and posterior mean m = beta * S * X^T y.
-
-        Parameters
-        ----------
-        X : array-like of shape (n_samples, n_features)
-            Training feature matrix (without bias column).
-        y : array-like of shape (n_samples,)
-            Training target vector.
-
-        Returns
-        -------
-        BayesianLinearRegressionScratch
-            The fitted model instance (self).
-        """
-        X_arr = np.array(X)
-        y_arr = np.array(y)
-
-        self.feature_means = np.mean(X_arr, axis=0)
-        self.feature_stds = np.std(X_arr, axis=0) + 1e-8
-        X_scaled = (X_arr - self.feature_means) / self.feature_stds
-
-        X_bias = np.hstack([np.ones((X_arr.shape[0], 1)), X_scaled])
-        num_features = X_bias.shape[1]
-
-        precision = self.alpha * np.eye(num_features) + self.beta * np.dot(
-            X_bias.T, X_bias
-        )
-        self.w_cov = np.linalg.inv(precision)
-        self.w_mean = self.beta * np.dot(self.w_cov, np.dot(X_bias.T, y_arr))
-        return self
-
-    def predict(self, X: Any) -> np.ndarray:
-        """Predict target values based on posterior mean.
-
-        Parameters
-        ----------
-        X : array-like of shape (n_samples, n_features)
-            Feature matrix for which to generate predictions.
-
-        Returns
-        -------
-        np.ndarray of shape (n_samples,)
-            Predicted target values using the posterior mean weights.
-        """
-        X_arr = np.array(X)
-        X_scaled = (X_arr - self.feature_means) / self.feature_stds
-        X_bias = np.hstack([np.ones((X_arr.shape[0], 1)), X_scaled])
-        return np.dot(X_bias, self.w_mean)
-
-
-class DecisionTreeRegressorScratch:
-    """Single Regression Tree used as building block for Random Forest."""
-
-    def __init__(self, max_depth: int = 5, min_samples_split: int = 2) -> None:
-        """Initialize the tree with depth and split constraints.
-
-        Parameters
-        ----------
-        max_depth : int, optional
-            Maximum depth of the tree. Growth stops once this depth is reached.
-            Default is 5.
-        min_samples_split : int, optional
-            Minimum number of samples required to attempt a split.
-            Default is 2.
-        """
-        self.max_depth = max_depth
-        self.min_samples_split = min_samples_split
-        self.feature_idx = -1
-        self.threshold = 0.0
-        self.value = 0.0
-        self.left: Optional["DecisionTreeRegressorScratch"] = None
-        self.right: Optional["DecisionTreeRegressorScratch"] = None
-
-    def fit(
-        self, X: np.ndarray, y: np.ndarray, depth: int = 0
-    ) -> "DecisionTreeRegressorScratch":
-        """Recursively build the decision tree structure.
-
-        At each node, exhaustively searches all features and thresholds to
-        find the split minimizing combined MSE of the two child nodes.
-
-        Parameters
-        ----------
-        X : np.ndarray of shape (n_samples, n_features)
-            Feature matrix for the current node.
-        y : np.ndarray of shape (n_samples,)
-            Target vector for the current node.
-        depth : int, optional
-            Current depth in the tree. Default is 0 (root).
-
-        Returns
-        -------
-        DecisionTreeRegressorScratch
-            The fitted node (self), which recursively contains child nodes.
-        """
-        num_samples, num_features = X.shape
-        self.value = float(np.mean(y))
-
-        if (
-            depth >= self.max_depth
-            or num_samples < self.min_samples_split
-            or np.all(y == y[0])
-        ):
-            return self
-
-        best_mse = float("inf")
-
-        for feat in range(num_features):
-            thresholds = np.unique(X[:, feat])
-            for thresh in thresholds:
-                left_mask = X[:, feat] <= thresh
-                right_mask = ~left_mask
-
-                if np.sum(left_mask) == 0 or np.sum(right_mask) == 0:
-                    continue
-
-                mse = np.sum((y[left_mask] - np.mean(y[left_mask])) ** 2) + np.sum(
-                    (y[right_mask] - np.mean(y[right_mask])) ** 2
-                )
-
-                if mse < best_mse:
-                    best_mse = mse
-                    self.feature_idx = feat
-                    self.threshold = thresh
-
-        if best_mse == float("inf"):
-            return self
-
-        left_idx = X[:, self.feature_idx] <= self.threshold
-        self.left = DecisionTreeRegressorScratch(
-            self.max_depth, self.min_samples_split
-        ).fit(X[left_idx], y[left_idx], depth + 1)
-        self.right = DecisionTreeRegressorScratch(
-            self.max_depth, self.min_samples_split
-        ).fit(X[~left_idx], y[~left_idx], depth + 1)
-        return self
-
-    def _predict_row(self, row: np.ndarray) -> float:
-        """Traverse the tree to predict the value for a single row.
-
-        Parameters
-        ----------
-        row : np.ndarray of shape (n_features,)
-            A single sample to predict.
-
-        Returns
-        -------
-        float
-            Predicted target value for the given sample.
-        """
-        if self.left is None or self.right is None:
-            return self.value
-        if row[self.feature_idx] <= self.threshold:
-            return self.left._predict_row(row)
-        return self.right._predict_row(row)
-
-    def predict(self, X: np.ndarray) -> np.ndarray:
-        """Predict target values for multiple data points.
-
-        Parameters
-        ----------
-        X : np.ndarray of shape (n_samples, n_features)
-            Feature matrix for which to generate predictions.
-
-        Returns
-        -------
-        np.ndarray of shape (n_samples,)
-            Predicted target values.
-        """
-        return np.array([self._predict_row(row) for row in X])
-
-
-class RandomForestRegressorScratch:
-    """Random Forest Regressor with bootstrapping and feature subsampling."""
-
-    def __init__(
-        self,
-        n_estimators: int = 50,
-        max_depth: int = 5,
-        max_features: Any = "sqrt",
-        seed: int = 42,
-    ) -> None:
-        """Initialize the ensemble parameters.
-
-        Parameters
-        ----------
-        n_estimators : int, optional
-            Number of decision trees to build. Default is 50.
-        max_depth : int, optional
-            Maximum depth for each individual tree. Default is 5.
-        max_features : int, str, optional
-            Number of features to consider at each split. Can be
-            ``'sqrt'`` (default), ``'log2'``, or an int. ``None`` means
-            all features.
-        seed : int, optional
-            Random seed for reproducible bootstrap sampling. Default is 42.
-        """
-        self.n_estimators = n_estimators
-        self.max_depth = max_depth
-        self.max_features = max_features
-        self.seed = seed
-        self.trees: List[tuple] = []
-
-    def fit(self, X: Any, y: Any) -> "RandomForestRegressorScratch":
-        """Build the forest of trees using bootstrapped subsets.
-
-        Each tree is trained on a bootstrap sample (sampling with replacement)
-        of the training data and a random subset of features at each split,
-        reducing variance via both bagging and feature subsampling.
-
-        Parameters
-        ----------
-        X : array-like of shape (n_samples, n_features)
-            Training feature matrix.
-        y : array-like of shape (n_samples,)
-            Training target vector.
-
-        Returns
-        -------
-        RandomForestRegressorScratch
-            The fitted ensemble model (self).
-        """
-        X_arr = np.array(X)
-        y_arr = np.array(y)
-        rng = np.random.default_rng(self.seed)
-        num_samples, n_features = X_arr.shape[0], X_arr.shape[1]
-        self.trees = []
-
-        if self.max_features == "sqrt":
-            m_features = max(1, int(np.sqrt(n_features)))
-        elif self.max_features == "log2":
-            m_features = max(1, int(np.log2(n_features)))
-        elif isinstance(self.max_features, int):
-            m_features = max(1, min(self.max_features, n_features))
-        else:
-            m_features = n_features
-
-        for _ in range(self.n_estimators):
-            # Bootstrap sampling
-            indices = rng.choice(num_samples, size=num_samples, replace=True)
-            X_b, y_b = X_arr[indices], y_arr[indices]
-
-            # Feature subsampling — each tree gets a random feature subset
-            feature_subset = rng.choice(n_features, size=m_features, replace=False)
-            X_b_sub = X_b[:, feature_subset]
-
-            tree = DecisionTreeRegressorScratch(max_depth=self.max_depth)
-            # Pass a virtual index range so the tree uses all available features
-            tree.fit(X_b_sub, y_b)
-            self.trees.append((tree, feature_subset))
-
-        return self
-
-    def predict(self, X: Any) -> np.ndarray:
-        """Aggregate predictions from all trees.
-
-        Each tree predicts using only its assigned feature subset.
-        Final prediction is the mean across all trees.
-
-        Parameters
-        ----------
-        X : array-like of shape (n_samples, n_features)
-            Feature matrix for which to generate predictions.
-
-        Returns
-        -------
-        np.ndarray of shape (n_samples,)
-            Averaged predicted target values across all trees.
-        """
-        X_arr = np.array(X)
-        tree_preds = np.array(
-            [tree.predict(X_arr[:, feat_sub]) for tree, feat_sub in self.trees]
-        )
-        return np.mean(tree_preds, axis=0)
-
-
 class AdvancedMethods:
     """Implements and evaluates advanced regression models for complex datasets."""
 
@@ -440,12 +132,6 @@ class AdvancedMethods:
 
         models = {
             "Kernel Ridge (From Scratch)": self.train_kernel_regression(
-                X_train, y_train
-            ),
-            "Bayesian Regression (From Scratch)": self.train_bayesian_regression(
-                X_train, y_train
-            ),
-            "Random Forest (From Scratch)": self.train_random_forest_regressor(
                 X_train, y_train
             ),
         }
@@ -474,52 +160,6 @@ class AdvancedMethods:
         model.fit(X_train, y_train)
         return model
 
-    def train_bayesian_regression(
-        self, X_train: pd.DataFrame, y_train: pd.Series
-    ) -> Any:
-        """Train a Custom Bayesian Linear Regression model from scratch.
-
-        Parameters
-        ----------
-        X_train : pd.DataFrame of shape (n_samples, n_features)
-            Training feature matrix.
-        y_train : pd.Series of shape (n_samples,)
-            Training target vector.
-
-        Returns
-        -------
-        BayesianLinearRegressionScratch
-            Fitted Bayesian Linear Regression model.
-        """
-        model = BayesianLinearRegressionScratch(alpha=1.0, beta=25.0)
-        model.fit(X_train, y_train)
-        return model
-
-    def train_random_forest_regressor(
-        self, X_train: pd.DataFrame, y_train: pd.Series, n_estimators: int = 50
-    ) -> Any:
-        """Train a Custom Random Forest Regressor from scratch.
-
-        Parameters
-        ----------
-        X_train : pd.DataFrame of shape (n_samples, n_features)
-            Training feature matrix.
-        y_train : pd.Series of shape (n_samples,)
-            Training target vector.
-        n_estimators : int, optional
-            Number of trees in the forest. Default is 50.
-
-        Returns
-        -------
-        RandomForestRegressorScratch
-            Fitted Random Forest Regression model.
-        """
-        model = RandomForestRegressorScratch(
-            n_estimators=n_estimators, max_depth=5, seed=42
-        )
-        model.fit(X_train, y_train)
-        return model
-
     def evaluate_advanced_models(
         self,
         X_train: pd.DataFrame,
@@ -527,11 +167,10 @@ class AdvancedMethods:
         X_test: pd.DataFrame,
         y_test: pd.Series,
     ) -> pd.DataFrame:
-        """Train and evaluate all custom advanced models and compile their metrics.
+        """Train and evaluate the Kernel Ridge model and compile its metrics.
 
-        Fits Kernel Ridge, Bayesian Linear, and Random Forest regressors on
-        the training data, evaluates each on the test set, and returns a
-        summary DataFrame of R², RMSE, and MAE.
+        Fits Kernel Ridge on the training data, evaluates on the test set,
+        and returns a summary DataFrame of R², RMSE, and MAE.
 
         Parameters
         ----------
@@ -630,9 +269,9 @@ class AdvancedMethods:
         X_test: pd.DataFrame,
         y_test: pd.Series,
     ) -> None:
-        """Plot predicted vs actual values for each advanced model.
+        """Plot predicted vs actual values for the Kernel Ridge model.
 
-        Uses cached models from ``_get_or_fit_models`` to avoid
+        Uses cached model from ``_get_or_fit_models`` to avoid
         retraining on every call.
 
         Parameters
@@ -653,15 +292,15 @@ class AdvancedMethods:
         """
         models = self._get_or_fit_models(X_train, y_train)
 
-        fig, axes = plt.subplots(1, 3, figsize=(15, 5))
+        fig, ax = plt.subplots(figsize=(6, 6))
         fig.suptitle(
-            "Predicted vs Actual Values — Advanced Models",
+            "Predicted vs Actual Values — Kernel Ridge",
             fontsize=14,
             fontweight="bold",
         )
         y_test_arr = np.array(y_test)
 
-        for ax, (name, model) in zip(axes, models.items()):
+        for name, model in models.items():
             y_pred = model.predict(X_test)
             ax.scatter(y_test_arr, y_pred, alpha=0.6, edgecolors="k", label="Samples")
             lims = [

--- a/part2/archive/bayesian_random_forest_models.py
+++ b/part2/archive/bayesian_random_forest_models.py
@@ -1,0 +1,294 @@
+"""Archived Bayesian, Decision Tree, and Random Forest models.
+
+These from-scratch implementations were removed from the main
+advanced_methods module because the spec requires only Kernel Ridge
+(or Bayesian) as a bonus technique — not both. Kernel Ridge was kept
+as the chosen advanced model.
+
+This archive preserves the working, tested code for reference.
+"""
+
+from typing import Any, List, Optional
+
+import numpy as np
+
+
+class BayesianLinearRegressionScratch:
+    """Bayesian Linear Regression using Gaussian Priors with Z-score scaling."""
+
+    def __init__(self, alpha: float = 1.0, beta: float = 25.0) -> None:
+        """Initialize the Bayesian Regression model with precision parameters.
+
+        Parameters
+        ----------
+        alpha : float, optional
+            Prior precision on coefficients. Controls the strength of the
+            Gaussian prior on weights. Larger values shrink coefficients
+            more strongly toward zero. Default is 1.0.
+        beta : float, optional
+            Noise precision (inverse variance). Models the expected noise
+            level in the target variable. Default is 25.0.
+        """
+        self.alpha = alpha
+        self.beta = beta
+        self.w_mean: Optional[np.ndarray] = None
+        self.w_cov: Optional[np.ndarray] = None
+        self.feature_means: Optional[np.ndarray] = None
+        self.feature_stds: Optional[np.ndarray] = None
+
+    def fit(self, X: Any, y: Any) -> "BayesianLinearRegressionScratch":
+        """Compute the posterior over weights given training data.
+
+        Uses the closed-form Bayesian update for linear regression with
+        a Gaussian prior (conjugate prior):  posterior N(w_mean, w_cov).
+
+        ``w_cov = (alpha * I + beta * X^T X)^{-1}``
+        ``w_mean = beta * w_cov * X^T y``
+
+        Features are Z-score normalized before fitting; the stored
+        ``feature_means`` and ``feature_stds`` are reused at predict time.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training feature matrix.
+        y : array-like of shape (n_samples,)
+            Training target vector.
+
+        Returns
+        -------
+        BayesianLinearRegressionScratch
+            The fitted model instance (self).
+        """
+        X_arr = np.array(X)
+        y_arr = np.array(y)
+
+        self.feature_means = np.mean(X_arr, axis=0)
+        self.feature_stds = np.std(X_arr, axis=0) + 1e-8
+        X_scaled = (X_arr - self.feature_means) / self.feature_stds
+
+        n_features = X_scaled.shape[1]
+        XtX = X_scaled.T @ X_scaled
+        self.w_cov = np.linalg.inv(self.alpha * np.eye(n_features) + self.beta * XtX)
+        self.w_mean = self.beta * self.w_cov @ X_scaled.T @ y_arr
+        return self
+
+    def predict(self, X: Any) -> np.ndarray:
+        """Predict target values using the posterior mean.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Feature matrix for which to generate predictions.
+
+        Returns
+        -------
+        np.ndarray of shape (n_samples,)
+            Predicted target values (posterior mean).
+        """
+        X_arr = np.array(X)
+        X_scaled = (X_arr - self.feature_means) / self.feature_stds
+        return X_scaled @ self.w_mean
+
+
+class DecisionTreeRegressorScratch:
+    """Single Regression Tree used as building block for Random Forest."""
+
+    def __init__(self, max_depth: int = 5, min_samples_split: int = 2) -> None:
+        """Initialize the tree with depth and leaf-size constraints.
+
+        Parameters
+        ----------
+        max_depth : int, optional
+            Maximum depth of the tree. Default is 5.
+        min_samples_split : int, optional
+            Minimum number of samples required to split a node. Default is 2.
+        """
+        self.max_depth = max_depth
+        self.min_samples_split = min_samples_split
+        self.tree: Optional[dict] = None
+
+    def fit(self, X: Any, y: Any) -> "DecisionTreeRegressorScratch":
+        """Build the decision tree by recursive binary splitting.
+
+        Splits are chosen by minimizing the Mean Squared Error (MSE)
+        of the target within each child region. Stops when max_depth
+        is reached or a node has fewer than min_samples_split samples.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training feature matrix.
+        y : array-like of shape (n_samples,)
+            Training target vector.
+
+        Returns
+        -------
+        DecisionTreeRegressorScratch
+            The fitted tree model (self).
+        """
+        X_arr = np.array(X)
+        y_arr = np.array(y).flatten()
+        self.tree = self._build_tree(X_arr, y_arr, depth=0)
+        return self
+
+    def _build_tree(self, X: np.ndarray, y: np.ndarray, depth: int) -> dict:
+        """Recursively build tree nodes."""
+        n_samples, n_features = X.shape
+        if n_samples < self.min_samples_split or depth >= self.max_depth:
+            return {"leaf": True, "mean": np.mean(y)}
+
+        best_mse = float("inf")
+        best_feat, best_thresh = None, None
+
+        for feat in range(n_features):
+            thresholds = np.unique(X[:, feat])
+            for t in thresholds:
+                left = y[X[:, feat] <= t]
+                right = y[X[:, feat] > t]
+                if len(left) == 0 or len(right) == 0:
+                    continue
+                mse = np.var(left) * len(left) + np.var(right) * len(right)
+                if mse < best_mse:
+                    best_mse = mse
+                    best_feat = feat
+                    best_thresh = t
+
+        if best_feat is None:
+            return {"leaf": True, "mean": np.mean(y)}
+
+        left_idx = X[:, best_feat] <= best_thresh
+        right_idx = ~left_idx
+
+        return {
+            "leaf": False,
+            "feature": best_feat,
+            "threshold": best_thresh,
+            "left": self._build_tree(X[left_idx], y[left_idx], depth + 1),
+            "right": self._build_tree(X[right_idx], y[right_idx], depth + 1),
+        }
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        """Predict target values by traversing the tree for each sample.
+
+        Parameters
+        ----------
+        X : np.ndarray of shape (n_samples, n_features)
+            Feature matrix for which to generate predictions.
+
+        Returns
+        -------
+        np.ndarray of shape (n_samples,)
+            Predicted target values.
+        """
+        X_arr = np.array(X)
+        return np.array([self._predict_row(row, self.tree) for row in X_arr])
+
+    def _predict_row(self, row: np.ndarray, node: dict) -> float:
+        """Traverse the tree for a single row."""
+        if node.get("leaf"):
+            return node["mean"]
+        if row[node["feature"]] <= node["threshold"]:
+            return self._predict_row(row, node["left"])
+        return self._predict_row(row, node["right"])
+
+
+class RandomForestRegressorScratch:
+    """Random Forest Regressor with bootstrapping and feature subsampling."""
+
+    def __init__(
+        self,
+        n_estimators: int = 50,
+        max_depth: int = 5,
+        max_features: Any = "sqrt",
+        seed: int = 42,
+    ) -> None:
+        """Initialize the ensemble parameters.
+
+        Parameters
+        ----------
+        n_estimators : int, optional
+            Number of decision trees to build. Default is 50.
+        max_depth : int, optional
+            Maximum depth for each individual tree. Default is 5.
+        max_features : int, str, optional
+            Number of features to consider at each split. Can be
+            ``'sqrt'`` (default), ``'log2'``, or an int. ``None`` means
+            all features.
+        seed : int, optional
+            Random seed for reproducible bootstrap sampling. Default is 42.
+        """
+        self.n_estimators = n_estimators
+        self.max_depth = max_depth
+        self.max_features = max_features
+        self.seed = seed
+        self.trees: List[tuple] = []
+
+    def fit(self, X: Any, y: Any) -> "RandomForestRegressorScratch":
+        """Build the forest of trees using bootstrapped subsets.
+
+        Each tree is trained on a bootstrap sample (sampling with replacement)
+        of the training data and a random subset of features at each split,
+        reducing variance via both bagging and feature subsampling.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training feature matrix.
+        y : array-like of shape (n_samples,)
+            Training target vector.
+
+        Returns
+        -------
+        RandomForestRegressorScratch
+            The fitted ensemble model (self).
+        """
+        X_arr = np.array(X)
+        y_arr = np.array(y)
+        rng = np.random.default_rng(self.seed)
+        num_samples, n_features = X_arr.shape[0], X_arr.shape[1]
+        self.trees = []
+
+        if self.max_features == "sqrt":
+            m_features = max(1, int(np.sqrt(n_features)))
+        elif self.max_features == "log2":
+            m_features = max(1, int(np.log2(n_features)))
+        elif isinstance(self.max_features, int):
+            m_features = max(1, min(self.max_features, n_features))
+        else:
+            m_features = n_features
+
+        for _ in range(self.n_estimators):
+            indices = rng.choice(num_samples, size=num_samples, replace=True)
+            X_b, y_b = X_arr[indices], y_arr[indices]
+
+            feature_subset = rng.choice(n_features, size=m_features, replace=False)
+            X_b_sub = X_b[:, feature_subset]
+
+            tree = DecisionTreeRegressorScratch(max_depth=self.max_depth)
+            tree.fit(X_b_sub, y_b)
+            self.trees.append((tree, feature_subset))
+
+        return self
+
+    def predict(self, X: Any) -> np.ndarray:
+        """Aggregate predictions from all trees.
+
+        Each tree predicts using only its assigned feature subset.
+        Final prediction is the mean across all trees.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Feature matrix for which to generate predictions.
+
+        Returns
+        -------
+        np.ndarray of shape (n_samples,)
+            Averaged predicted target values across all trees.
+        """
+        X_arr = np.array(X)
+        tree_preds = np.array(
+            [tree.predict(X_arr[:, feat_sub]) for tree, feat_sub in self.trees]
+        )
+        return np.mean(tree_preds, axis=0)

--- a/part2/archive/lasso_elasticnet_models.py
+++ b/part2/archive/lasso_elasticnet_models.py
@@ -1,0 +1,97 @@
+"""Archived Lasso and ElasticNet models.
+
+These implementations were removed from the main model_comparison module
+because the spec requires only Ridge (or Lasso) — not both. Ridge was kept
+as the primary regularized model.
+
+This archive preserves the working, tested code for reference.
+"""
+
+from typing import Any
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import Lasso, ElasticNet
+from sklearn.preprocessing import StandardScaler
+
+
+def train_lasso_regression(
+    X_train: pd.DataFrame, y_train: pd.Series, alpha: float = 1.0
+) -> dict:
+    """
+    Train a Lasso Regression model with internal Z-score scaling.
+
+    Scales features internally via ``StandardScaler`` and stores the
+    scaler alongside the fitted model so evaluation can apply the same
+    transformation on test data.
+
+    Parameters
+    ----------
+    X_train : pd.DataFrame
+        The training feature data.
+    y_train : pd.Series
+        The training target data.
+    alpha : float, optional
+        Regularization strength (default is 1.0).
+
+    Returns
+    -------
+    dict
+        A dict with ``"model"``, ``"type"``, ``"scaler"``, and
+        ``"feature_names"`` for use by ``evaluate_model``.
+    """
+    scaler = StandardScaler()
+    X_scaled = scaler.fit_transform(np.asarray(X_train, dtype=float))
+
+    model = Lasso(alpha=alpha, random_state=42, max_iter=10000)
+    model.fit(X_scaled, y_train)
+
+    return {
+        "model": model,
+        "type": "lasso",
+        "scaler": scaler,
+        "feature_names": list(X_train.columns),
+    }
+
+
+def train_elasticnet_regression(
+    X_train: pd.DataFrame,
+    y_train: pd.Series,
+    alpha: float = 1.0,
+    l1_ratio: float = 0.5,
+) -> dict:
+    """
+    Train an ElasticNet Regression model with internal Z-score scaling.
+
+    Scales features internally via ``StandardScaler`` and stores the
+    scaler alongside the fitted model so evaluation can apply the same
+    transformation on test data.
+
+    Parameters
+    ----------
+    X_train : pd.DataFrame
+        The training feature data.
+    y_train : pd.Series
+        The training target data.
+    alpha : float, optional
+        Constant that multiplies the penalty terms (default is 1.0).
+    l1_ratio : float, optional
+        The ElasticNet mixing parameter (default is 0.5).
+
+    Returns
+    -------
+    dict
+        A dict with ``"model"``, ``"type"``, ``"scaler"``, and
+        ``"feature_names"`` for use by ``evaluate_model``.
+    """
+    scaler = StandardScaler()
+    X_scaled = scaler.fit_transform(np.asarray(X_train, dtype=float))
+
+    model = ElasticNet(alpha=alpha, l1_ratio=l1_ratio, random_state=42, max_iter=10000)
+    model.fit(X_scaled, y_train)
+
+    return {
+        "model": model,
+        "type": "elasticnet",
+        "scaler": scaler,
+        "feature_names": list(X_train.columns),
+    }

--- a/part2/archive/test_archived_models.py
+++ b/part2/archive/test_archived_models.py
@@ -1,0 +1,198 @@
+"""Tests for archived out-of-scope models.
+
+Corresponding tests for the archived out-of-scope models. These tests
+were originally part of test_model_comparison.py and
+test_advanced_methods.py.
+
+They are preserved here to verify that the archived code remains functional.
+"""
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.append(str(PROJECT_ROOT))
+
+import unittest
+import numpy as np
+import pandas as pd
+
+from part2.model_comparison import ModelComparison
+from part2.archive.lasso_elasticnet_models import (
+    train_lasso_regression,
+    train_elasticnet_regression,
+)
+from part2.archive.bayesian_random_forest_models import (
+    BayesianLinearRegressionScratch,
+    DecisionTreeRegressorScratch,
+    RandomForestRegressorScratch,
+)
+
+
+class TestArchivedLassoElasticNet(unittest.TestCase):
+    """Tests for archived Lasso and ElasticNet implementations."""
+
+    def setUp(self):
+        np.random.seed(123)
+        n = 100
+        X_raw = np.random.randn(n, 4)
+        coefs = np.array([1.5, -0.8, 0.0, 2.3])
+        y_raw = 3.0 + X_raw @ coefs + 0.2 * np.random.randn(n)
+        self.X_train = pd.DataFrame(X_raw[:70], columns=["a", "b", "c", "d"])
+        self.y_train = pd.Series(y_raw[:70])
+
+    def test_lasso_returns_sklearn_model(self):
+        """train_lasso_regression() returns a dict with an sklearn Lasso."""
+        result = train_lasso_regression(self.X_train, self.y_train, alpha=0.1)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["type"], "lasso")
+        self.assertTrue(hasattr(result["model"], "coef_"))
+
+    def test_lasso_shrinks_weak_features(self):
+        """Lasso with large alpha shrinks weak features to exactly zero."""
+        result = train_lasso_regression(self.X_train, self.y_train, alpha=10.0)
+        self.assertEqual(result["model"].coef_[2], 0.0)
+
+    def test_elasticnet_returns_sklearn_model(self):
+        """train_elasticnet_regression() returns a dict with an sklearn ElasticNet."""
+        result = train_elasticnet_regression(self.X_train, self.y_train, alpha=0.1)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["type"], "elasticnet")
+        self.assertTrue(hasattr(result["model"], "coef_"))
+
+
+class TestArchivedBayesianRegression(unittest.TestCase):
+    """Tests for archived BayesianLinearRegressionScratch."""
+
+    def setUp(self):
+        np.random.seed(42)
+        n = 100
+        self.X_train = pd.DataFrame(
+            {"x1": np.random.randn(n), "x2": np.random.randn(n)}
+        )
+        self.y_train = pd.Series(
+            2.0
+            + self.X_train["x1"] * 1.5
+            + self.X_train["x2"] * (-0.8)
+            + 0.2 * np.random.randn(n)
+        )
+
+    def test_fit_stores_posterior_mean(self):
+        """fit() stores w_mean with correct shape."""
+        model = BayesianLinearRegressionScratch(alpha=1.0, beta=25.0)
+        model.fit(self.X_train, self.y_train)
+        self.assertIsNotNone(model.w_mean)
+        self.assertEqual(model.w_mean.shape[0], 2)
+
+    def test_fit_stores_posterior_covariance(self):
+        """fit() stores w_cov."""
+        model = BayesianLinearRegressionScratch(alpha=1.0, beta=25.0)
+        model.fit(self.X_train, self.y_train)
+        self.assertIsNotNone(model.w_cov)
+        self.assertEqual(model.w_cov.shape, (2, 2))
+
+    def test_fit_stores_scaler_params(self):
+        """fit() stores feature_means and feature_stds."""
+        model = BayesianLinearRegressionScratch(alpha=1.0, beta=25.0)
+        model.fit(self.X_train, self.y_train)
+        self.assertIsNotNone(model.feature_means)
+        self.assertIsNotNone(model.feature_stds)
+        self.assertEqual(len(model.feature_means), 2)
+
+    def test_predict_returns_correct_shape(self):
+        """predict() returns shape (n_test,)."""
+        model = BayesianLinearRegressionScratch(alpha=1.0, beta=25.0)
+        model.fit(self.X_train, self.y_train)
+        X_test = pd.DataFrame({"x1": np.random.randn(20), "x2": np.random.randn(20)})
+        preds = model.predict(X_test)
+        self.assertEqual(preds.shape, (20,))
+
+
+class TestArchivedDecisionTree(unittest.TestCase):
+    """Tests for archived DecisionTreeRegressorScratch."""
+
+    def setUp(self):
+        np.random.seed(42)
+        self.X_step = np.array([[1], [2], [3], [4], [5], [6]])
+        self.y_step = np.array([0, 0, 0, 1, 1, 1])
+
+    def test_fit_perfect_on_step_function(self):
+        """DecisionTree with sufficient depth fits a step function perfectly."""
+        model = DecisionTreeRegressorScratch(max_depth=5)
+        model.fit(self.X_step, self.y_step)
+        preds = model.predict(self.X_step)
+        np.testing.assert_array_equal(preds, self.y_step)
+
+    def test_max_depth_limits_growth(self):
+        """Shallow tree has higher error than deep tree on non-linear data."""
+        np.random.seed(7)
+        X = np.random.randn(50, 1)
+        y = np.sin(X[:, 0] * 3) + 0.1 * np.random.randn(50)
+        deep = DecisionTreeRegressorScratch(max_depth=10)
+        shallow = DecisionTreeRegressorScratch(max_depth=2)
+        deep.fit(X, y)
+        shallow.fit(X, y)
+        deep_preds = deep.predict(X)
+        shallow_preds = shallow.predict(X)
+        deep_mse = np.mean((y - deep_preds) ** 2)
+        shallow_mse = np.mean((y - shallow_preds) ** 2)
+        self.assertLess(deep_mse, shallow_mse)
+
+    def test_constant_feature_no_split(self):
+        """Tree handles constant features without crashing."""
+        X = np.column_stack([np.ones(20), np.random.randn(20)])
+        y = np.random.randn(20)
+        model = DecisionTreeRegressorScratch(max_depth=3)
+        model.fit(X, y)  # should not raise
+
+    def test_predict_shapes(self):
+        """predict() returns correct shape."""
+        X = np.random.randn(10, 2)
+        y = np.random.randn(10)
+        model = DecisionTreeRegressorScratch(max_depth=5)
+        model.fit(X, y)
+        preds = model.predict(np.random.randn(5, 2))
+        self.assertEqual(preds.shape, (5,))
+
+
+class TestArchivedRandomForest(unittest.TestCase):
+    """Tests for archived RandomForestRegressorScratch."""
+
+    def setUp(self):
+        np.random.seed(42)
+        self.X = np.random.randn(50, 3)
+        y_true = self.X[:, 0] * 2 + self.X[:, 1] * (-1) + 0.2 * np.random.randn(50)
+        self.y = y_true
+
+    def test_fit_stores_trees(self):
+        """RandomForest.fit() stores the correct number of trees."""
+        model = RandomForestRegressorScratch(n_estimators=5, max_depth=3, seed=42)
+        model.fit(self.X, self.y)
+        self.assertEqual(len(model.trees), 5)
+
+    def test_predict_shape(self):
+        """RandomForest.predict() returns correct shape."""
+        model = RandomForestRegressorScratch(n_estimators=5, max_depth=3, seed=42)
+        model.fit(self.X, self.y)
+        preds = model.predict(np.random.randn(10, 3))
+        self.assertEqual(preds.shape, (10,))
+
+    def test_predict_single_tree_versus_ensemble(self):
+        """Ensemble with more trees has lower MSE than a single tree."""
+        np.random.seed(42)
+        n = 100
+        X = np.random.randn(n, 3)
+        y = X[:, 0] * 2 + X[:, 1] * (-1) + 0.3 * np.random.randn(n)
+        single = RandomForestRegressorScratch(n_estimators=1, max_depth=4, seed=42)
+        ensemble = RandomForestRegressorScratch(n_estimators=10, max_depth=4, seed=42)
+        single.fit(X, y)
+        ensemble.fit(X, y)
+        single_preds = single.predict(X)
+        ensemble_preds = ensemble.predict(X)
+        single_mse = np.mean((y - single_preds) ** 2)
+        ensemble_mse = np.mean((y - ensemble_preds) ** 2)
+        self.assertLess(ensemble_mse, single_mse)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/part2/model_comparison.py
+++ b/part2/model_comparison.py
@@ -2,7 +2,7 @@
 Model Comparison Module.
 
 This module provides the ModelComparison class to train, evaluate,
-and compare multiple regression models.
+and compare OLS and Ridge regression models.
 """
 
 from typing import Dict, Any, List, Tuple
@@ -11,13 +11,11 @@ import numpy as np
 import matplotlib.pyplot as plt
 import scipy.stats as stats
 
-from sklearn.linear_model import Lasso, ElasticNet
 from sklearn.metrics import (
     mean_absolute_error,
     mean_squared_error,
     r2_score,
 )
-from sklearn.preprocessing import StandardScaler
 
 from part1.ols_implementation import (
     ols_fit,
@@ -35,12 +33,7 @@ from part1.ridge_lasso import (
 
 
 class ModelComparison:
-    """
-    Trains and compares multiple regression models.
-
-    Supports Linear Regression, Ridge Regression, Lasso Regression,
-    and ElasticNet Regression.
-    """
+    """Trains and compares OLS and Ridge regression models."""
 
     def __init__(self) -> None:
         """Initialize the ModelComparison object."""
@@ -109,90 +102,6 @@ class ModelComparison:
             "feature_names": feature_names,
         }
 
-    def train_lasso_regression(
-        self, X_train: pd.DataFrame, y_train: pd.Series, alpha: float = 1.0
-    ) -> Any:
-        """
-        Train a Lasso Regression model with internal Z-score scaling.
-
-        Scales features internally via ``StandardScaler`` and stores the
-        scaler alongside the fitted model so ``evaluate_model`` can apply
-        the same transformation on test data.
-
-        Parameters
-        ----------
-        X_train : pd.DataFrame
-            The training feature data.
-        y_train : pd.Series
-            The training target data.
-        alpha : float, optional
-            Regularization strength (default is 1.0).
-
-        Returns
-        -------
-        Any
-            A dict with ``"model"``, ``"type"``, and ``"scaler"`` for use
-            by ``evaluate_model``.
-        """
-        scaler = StandardScaler()
-        X_scaled = scaler.fit_transform(np.asarray(X_train, dtype=float))
-
-        model = Lasso(alpha=alpha, random_state=42, max_iter=10000)
-        model.fit(X_scaled, y_train)
-
-        return {
-            "model": model,
-            "type": "lasso",
-            "scaler": scaler,
-            "feature_names": list(X_train.columns),
-        }
-
-    def train_elasticnet_regression(
-        self,
-        X_train: pd.DataFrame,
-        y_train: pd.Series,
-        alpha: float = 1.0,
-        l1_ratio: float = 0.5,
-    ) -> Any:
-        """
-        Train an ElasticNet Regression model with internal Z-score scaling.
-
-        Scales features internally via ``StandardScaler`` and stores the
-        scaler alongside the fitted model so ``evaluate_model`` can apply
-        the same transformation on test data.
-
-        Parameters
-        ----------
-        X_train : pd.DataFrame
-            The training feature data.
-        y_train : pd.Series
-            The training target data.
-        alpha : float, optional
-            Constant that multiplies the penalty terms (default is 1.0).
-        l1_ratio : float, optional
-            The ElasticNet mixing parameter (default is 0.5).
-
-        Returns
-        -------
-        Any
-            A dict with ``"model"``, ``"type"``, and ``"scaler"`` for use
-            by ``evaluate_model``.
-        """
-        scaler = StandardScaler()
-        X_scaled = scaler.fit_transform(np.asarray(X_train, dtype=float))
-
-        model = ElasticNet(
-            alpha=alpha, l1_ratio=l1_ratio, random_state=42, max_iter=10000
-        )
-        model.fit(X_scaled, y_train)
-
-        return {
-            "model": model,
-            "type": "elasticnet",
-            "scaler": scaler,
-            "feature_names": list(X_train.columns),
-        }
-
     def evaluate_model(
         self, model: Any, X_test: pd.DataFrame, y_test: pd.Series
     ) -> Dict[str, float]:
@@ -234,10 +143,6 @@ class ModelComparison:
                 X_scaled = (X - model["feature_means"]) / model["feature_stds"]
                 X_aug = np.column_stack([np.ones(len(X_scaled)), X_scaled])
                 y_pred = X_aug @ model["beta_hat"]
-            elif "scaler" in model:
-                # Lasso / ElasticNet via sklearn: use stored StandardScaler
-                X_scaled = model["scaler"].transform(X)
-                y_pred = model["model"].predict(X_scaled)
             else:
                 y_pred = model.predict(X_test)
         else:
@@ -393,14 +298,6 @@ class ModelComparison:
         results[f"Ridge (λ={best_ridge_alpha:.4f})"] = self.evaluate_model(
             ridge, X_test, y_test
         )
-
-        # Lasso with CV (using sklearn — no from-scratch lasso exists)
-        lasso = self.train_lasso_regression(X_train, y_train)
-        results["Lasso (α=1.0)"] = self.evaluate_model(lasso, X_test, y_test)
-
-        # ElasticNet (using sklearn — no from-scratch elasticnet exists)
-        elasticnet = self.train_elasticnet_regression(X_train, y_train)
-        results["ElasticNet"] = self.evaluate_model(elasticnet, X_test, y_test)
 
         return pd.DataFrame(results).T
 

--- a/tests/test_advanced_methods.py
+++ b/tests/test_advanced_methods.py
@@ -1,8 +1,7 @@
 """
 Unit tests for the Advanced Methods module.
 
-Tests all four from-scratch models (KernelRidge, Bayesian,
-DecisionTree, RandomForest) and the AdvancedMethods facade.
+Tests KernelRidge and the AdvancedMethods facade.
 """
 
 import sys
@@ -20,9 +19,6 @@ matplotlib.use("Agg")  # non-interactive backend for plot tests
 
 from part2.advanced_methods import (
     KernelRidgeScratch,
-    BayesianLinearRegressionScratch,
-    DecisionTreeRegressorScratch,
-    RandomForestRegressorScratch,
     AdvancedMethods,
 )
 
@@ -88,167 +84,6 @@ class TestKernelRidgeScratch(unittest.TestCase):
         self.assertTrue(np.all(np.abs(y_pred) < 1.0))
 
 
-class TestBayesianLinearRegressionScratch(unittest.TestCase):
-    """Tests for BayesianLinearRegressionScratch: fit, predict, posterior."""
-
-    def setUp(self):
-        """Set up a linear synthetic dataset."""
-        np.random.seed(123)
-        n = 80
-        self.X_train = pd.DataFrame(
-            {"x1": np.random.randn(n), "x2": np.random.randn(n)}
-        )
-        self.y_train = pd.Series(
-            -1
-            + self.X_train["x1"] * 3
-            + self.X_train["x2"] * 0.5
-            + 0.2 * np.random.randn(n)
-        )
-        self.X_test = pd.DataFrame(
-            {"x1": np.random.randn(20), "x2": np.random.randn(20)}
-        )
-
-    def test_fit_stores_posterior_mean(self):
-        """BayesianLinearRegressionScratch.fit() stores w_mean with correct shape."""
-        model = BayesianLinearRegressionScratch(alpha=1.0, beta=25.0)
-        model.fit(self.X_train, self.y_train)
-
-        self.assertIsNotNone(model.w_mean)
-        self.assertEqual(model.w_mean.shape, (3,))  # bias + 2 features
-
-    def test_fit_stores_posterior_covariance(self):
-        """BayesianLinearRegressionScratch.fit() stores w_cov."""
-        model = BayesianLinearRegressionScratch(alpha=1.0, beta=25.0)
-        model.fit(self.X_train, self.y_train)
-
-        self.assertIsNotNone(model.w_cov)
-        self.assertEqual(model.w_cov.shape, (3, 3))
-
-    def test_fit_stores_scaler_params(self):
-        """BayesianLinearRegressionScratch.fit() stores feature_means and feature_stds."""
-        model = BayesianLinearRegressionScratch(alpha=1.0, beta=25.0)
-        model.fit(self.X_train, self.y_train)
-
-        self.assertIsNotNone(model.feature_means)
-        self.assertIsNotNone(model.feature_stds)
-
-    def test_predict_returns_correct_shape(self):
-        """BayesianLinearRegressionScratch.predict() returns shape (n_test,)."""
-        model = BayesianLinearRegressionScratch(alpha=1.0, beta=25.0)
-        model.fit(self.X_train, self.y_train)
-        y_pred = model.predict(self.X_test)
-
-        self.assertEqual(y_pred.shape, (20,))
-        self.assertTrue(np.all(np.isfinite(y_pred)))
-
-
-class TestDecisionTreeRegressorScratch(unittest.TestCase):
-    """Tests for DecisionTreeRegressorScratch: fit, predict, depth control."""
-
-    def setUp(self):
-        """Set up step-function data that a tree can fit perfectly."""
-        np.random.seed(42)
-        n = 40
-        self.x = np.linspace(0, 1, n).reshape(-1, 1)
-        # Step function: 0 for x < 0.5, 1 for x >= 0.5
-        self.y = np.where(self.x.flatten() < 0.5, 0.0, 1.0)
-        self.y_noisy = self.y + 0.05 * np.random.randn(n)
-
-    def test_fit_perfect_on_step_function(self):
-        """DecisionTree with sufficient depth fits a step function perfectly."""
-        model = DecisionTreeRegressorScratch(max_depth=5)
-        model.fit(self.x, self.y_noisy)
-        y_pred = model.predict(self.x)
-
-        # Predictions should be close to the clean step values
-        mse = np.mean((y_pred - self.y) ** 2)
-        self.assertLess(mse, 0.01)
-
-    def test_max_depth_limits_growth(self):
-        """Shallow tree has higher error on noisy step function."""
-        deep = DecisionTreeRegressorScratch(max_depth=10)
-        shallow = DecisionTreeRegressorScratch(max_depth=2)
-
-        deep.fit(self.x, self.y_noisy)
-        shallow.fit(self.x, self.y_noisy)
-
-        pred_deep = deep.predict(self.x)
-        pred_shallow = shallow.predict(self.x)
-
-        # Shallow tree has fewer splits -> less flexibility
-        mse_deep = np.mean((pred_deep - self.y_noisy) ** 2)
-        mse_shallow = np.mean((pred_shallow - self.y_noisy) ** 2)
-        self.assertLess(mse_deep, mse_shallow)
-
-    def test_predict_shapes(self):
-        """DecisionTree.predict() returns correct shape."""
-        model = DecisionTreeRegressorScratch(max_depth=5)
-        model.fit(self.x, self.y_noisy)
-
-        test_x = np.array([[0.2], [0.8]])
-        y_pred = model.predict(test_x)
-        self.assertEqual(y_pred.shape, (2,))
-
-    def test_constant_feature_no_split(self):
-        """Tree with constant feature returns mean value (no split)."""
-        X_const = np.ones((10, 1))
-        y_const = np.array([5.0] * 10)
-
-        model = DecisionTreeRegressorScratch(max_depth=5)
-        model.fit(X_const, y_const)
-        y_pred = model.predict(np.array([[1.0], [1.0]]))
-
-        np.testing.assert_allclose(y_pred, [5.0, 5.0])
-
-
-class TestRandomForestRegressorScratch(unittest.TestCase):
-    """Tests for RandomForestRegressorScratch: fit, predict, ensemble effect."""
-
-    def setUp(self):
-        """Set up nonlinear dataset where RF ensemble helps."""
-        np.random.seed(42)
-        n = 60
-        x = np.random.randn(n, 3)
-        # Nonlinear target: interaction + quadratic
-        y = x[:, 0] ** 2 + np.sin(x[:, 1]) - x[:, 2] + 0.1 * np.random.randn(n)
-        self.X = pd.DataFrame(x, columns=["a", "b", "c"])
-        self.y = pd.Series(y)
-
-    def test_fit_stores_trees(self):
-        """RandomForest.fit() stores the correct number of trees."""
-        model = RandomForestRegressorScratch(n_estimators=5, max_depth=3, seed=42)
-        model.fit(self.X, self.y)
-
-        self.assertEqual(len(model.trees), 5)
-
-    def test_predict_shape(self):
-        """RandomForest.predict() returns correct shape."""
-        model = RandomForestRegressorScratch(n_estimators=5, max_depth=3, seed=42)
-        model.fit(self.X, self.y)
-        y_pred = model.predict(self.X)
-
-        self.assertEqual(y_pred.shape, (60,))
-
-    def test_predict_single_tree_versus_ensemble(self):
-        """Ensemble should have lower or equal MSE than a single tree.
-
-        n_estimators=10 vs n_estimators=1 — ensemble reduces variance.
-        """
-        single = RandomForestRegressorScratch(n_estimators=1, max_depth=4, seed=42)
-        ensemble = RandomForestRegressorScratch(n_estimators=10, max_depth=4, seed=42)
-
-        single.fit(self.X, self.y)
-        ensemble.fit(self.X, self.y)
-
-        pred_single = single.predict(self.X)
-        pred_ensemble = ensemble.predict(self.X)
-
-        mse_single = np.mean((pred_single - self.y) ** 2)
-        mse_ensemble = np.mean((pred_ensemble - self.y) ** 2)
-
-        self.assertLessEqual(mse_ensemble, mse_single * 1.05)
-
-
 class TestAdvancedMethods(unittest.TestCase):
     """Tests for AdvancedMethods facade: cache, evaluation, plotting."""
 
@@ -276,15 +111,13 @@ class TestAdvancedMethods(unittest.TestCase):
         )
 
     def test_get_or_fit_models_returns_dict(self):
-        """_get_or_fit_models() returns a dict with the three model types."""
+        """_get_or_fit_models() returns a dict with the Kernel Ridge model."""
         am = AdvancedMethods()
         models = am._get_or_fit_models(self.X_train, self.y_train)
 
         self.assertIsInstance(models, dict)
-        self.assertEqual(len(models), 3)
+        self.assertEqual(len(models), 1)
         self.assertIn("Kernel Ridge (From Scratch)", models)
-        self.assertIn("Bayesian Regression (From Scratch)", models)
-        self.assertIn("Random Forest (From Scratch)", models)
 
     def test_get_or_fit_models_cache_hit(self):
         """_get_or_fit_models() returns the same dict on repeat calls (identity cache)."""
@@ -316,7 +149,7 @@ class TestAdvancedMethods(unittest.TestCase):
         self.assertIn("R-squared", df.columns)
         self.assertIn("RMSE", df.columns)
         self.assertIn("MAE", df.columns)
-        self.assertEqual(len(df), 3)
+        self.assertEqual(len(df), 1)
 
     def test_evaluate_advanced_models_reasonable_metrics(self):
         """All models should achieve R² > 0 on a linear-ish dataset."""

--- a/tests/test_model_comparison.py
+++ b/tests/test_model_comparison.py
@@ -222,32 +222,6 @@ class TestModelComparison(unittest.TestCase):
         # All non-intercept coefficients should be near zero
         self.assertLess(np.max(np.abs(ridge["beta_hat"][1:])), 0.1)
 
-    def test_train_lasso_returns_sklearn_model(self):
-        """train_lasso_regression() returns a dict with an sklearn Lasso."""
-        comp = ModelComparison()
-        result = comp.train_lasso_regression(self.X_train, self.y_train, alpha=0.1)
-
-        self.assertIsInstance(result, dict)
-        self.assertEqual(result["type"], "lasso")
-        self.assertTrue(hasattr(result["model"], "coef_"))
-
-    def test_train_lasso_shrinks_weak_features(self):
-        """Lasso with large alpha shrinks weak features to exactly zero."""
-        comp = ModelComparison()
-        result = comp.train_lasso_regression(self.X_train, self.y_train, alpha=10.0)
-
-        # Feature 'c' (index 2) has true coefficient 0.0 — should be zero
-        self.assertEqual(result["model"].coef_[2], 0.0)
-
-    def test_train_elasticnet_returns_sklearn_model(self):
-        """train_elasticnet_regression() returns a dict with an sklearn ElasticNet."""
-        comp = ModelComparison()
-        result = comp.train_elasticnet_regression(self.X_train, self.y_train, alpha=0.1)
-
-        self.assertIsInstance(result, dict)
-        self.assertEqual(result["type"], "elasticnet")
-        self.assertTrue(hasattr(result["model"], "coef_"))
-
     # ── Compare metrics ──────────────────────────────────────────
 
     def test_compare_metrics_returns_dataframe(self):
@@ -261,15 +235,13 @@ class TestModelComparison(unittest.TestCase):
         self.assertIn("R2_test", df.columns)
 
     def test_compare_metrics_includes_all_models(self):
-        """compare_metrics() contains OLS, Ridge, Lasso, ElasticNet."""
+        """compare_metrics() contains OLS and Ridge."""
         comp = ModelComparison()
         df = comp.compare_metrics(self.X_train, self.y_train, self.X_test, self.y_test)
 
         model_names = df.index.tolist()
         self.assertTrue(any("OLS" in n for n in model_names))
         self.assertTrue(any("Ridge" in n for n in model_names))
-        self.assertTrue(any("Lasso" in n for n in model_names))
-        self.assertTrue(any("Elastic" in n for n in model_names))
 
     # ── CV ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Archives out-of-scope model implementations to `part2/archive/` per the spec (Ridge OR Lasso required — Ridge kept; Kernel Ridge OR Bayesian bonus — Kernel Ridge kept; ElasticNet, DecisionTree, RandomForest not in spec).

### Files added — `part2/archive/`
- **`lasso_elasticnet_models.py`** — sklearn Lasso + ElasticNet with StandardScaler (97 lines)
- **`bayesian_random_forest_models.py`** — from-scratch Bayesian Linear Regression, Decision Tree, Random Forest (294 lines)
- **`test_archived_models.py`** — 14 tests covering all archived models, all passing

### Files modified
- **`model_comparison.py`** — stripped Lasso/ElasticNet; keeps OLS + Ridge only
- **`advanced_methods.py`** — stripped Bayesian/DecisionTree/RandomForest; keeps Kernel Ridge only (plots simplified to single-subplot)
- **`test_model_comparison.py`** — removed 3 Lasso/ElasticNet tests; updated assertion
- **`test_advanced_methods.py`** — removed 3 test classes (11 tests); updated facade assertions

### Testing
- 117 tests pass (103 main + 14 archive)
- Archive modules import cleanly in isolation